### PR TITLE
Add option for Helm `--include-crds`

### DIFF
--- a/lib/helm/chart2json.nix
+++ b/lib/helm/chart2json.nix
@@ -18,6 +18,8 @@ with lib;
     values ? {},
     # kubernetes version to template chart for
     kubeVersion ? null,
+    # whether to include CRD
+    includeCRDs ? false
   }: let
     valuesJsonFile = builtins.toFile "${name}-values.json" (builtins.toJSON values);
   in
@@ -29,6 +31,7 @@ with lib;
           ${optionalString (kubeVersion != null) "--kube-version ${kubeVersion}"} \
           ${optionalString (namespace != null) "--namespace ${namespace}"} \
           ${optionalString (values != {}) "-f ${valuesJsonFile}"} \
+          ${optionalString (includeCRDs) "--include-crds"} \
           ${chart} >resources.yaml
 
         # split multy yaml file into multiple files

--- a/modules/helm.nix
+++ b/modules/helm.nix
@@ -81,6 +81,20 @@ in {
             default = true;
           };
 
+          includeCRDs = mkOption {
+            description = '' 
+              Whether to include CRDs.
+
+              Warning: Always including CRDs here is dangerous and can break CRs in your cluster as CRDs may be updated unintentionally.
+              An interactive `helm install` NEVER updates CRDs, only installs them when they are not existing.
+              See https://github.com/helm/community/blob/aa8e13054d91ee69857b13149a9652be09133a61/hips/hip-0011.md
+            
+              Only set this to true if you know what you are doing and are manually checking the included CRDs for breaking changes whenever updating the Helm chart.
+            '';
+            type = types.bool;
+            default = false;
+          };
+
           objects = mkOption {
             description = "Generated kubernetes objects";
             type = types.listOf types.attrs;
@@ -95,7 +109,7 @@ in {
         ];
 
         config.objects = importJSON (helm.chart2json {
-          inherit (config) chart name namespace values kubeVersion;
+          inherit (config) chart name namespace values kubeVersion includeCRDs;
         });
       }));
       default = {};


### PR DESCRIPTION
I consider that a feature for powerusers.

My use case is not “interactive” use of the kubenix CLI but only as a library for generating k8s JSON. I then use that in ArgoCD using a ArgoCD config management plugin which calls `nix build`.

I think `includeCRDs` should be off by default as users of kubenix which turn it on need to carefully check for updates of all included CRDs when updating the chart.

This is the policy that Helm decided on as well: Helm will only initially install CRDs, never update them.