### PR TITLE
Preserve array order

### DIFF
--- a/modules/generated/v1.19.nix
+++ b/modules/generated/v1.19.nix
@@ -4,6 +4,21 @@
 with lib;
 
 let
+  hasAttrNotNull = attr: set: hasAttr attr set && !isNull set.${attr};
+
+  attrsToList = values:
+    if values != null
+    then
+      sort
+        (a: b:
+          if (hasAttrNotNull "_priority" a && hasAttrNotNull "_priority" b)
+          then a._priority < b._priority
+          else false
+        )
+        (mapAttrsToList (n: v: v) values)
+    else
+      values;
+
   getDefaults = resource: group: version: kind:
     catAttrs "default" (filter
       (default:
@@ -51,15 +66,16 @@ let
 
   mkOptionDefault = mkOverride 1001;
 
+  # todo: can we use mkOrder
   mergeValuesByKey = mergeKey: values:
-    listToAttrs (map
-      (value: nameValuePair
+    listToAttrs (imap0
+      (i: value: nameValuePair
         (
           if isAttrs value.${mergeKey}
           then toString value.${mergeKey}.content
           else (toString value.${mergeKey})
         )
-        value)
+        (value // { _priority = i; }))
       values);
 
   submoduleOf = ref: types.submodule ({ name, ... }: {
@@ -75,7 +91,10 @@ let
         else name;
     in
     {
-      options = definitions."${ref}".options;
+      options = definitions."${ref}".options // {
+        # position in original array
+        _priority = mkOption { type = types.nullOr types.int; default = null; };
+      };
       config = definitions."${ref}".config // {
         ${mergeKey} = mkOverride 1002 (convertName name);
       };
@@ -186,7 +205,7 @@ let
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.MutatingWebhook" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -365,7 +384,7 @@ let
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.ValidatingWebhook" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -513,7 +532,7 @@ let
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1beta1.MutatingWebhook" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -694,7 +713,7 @@ let
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1beta1.ValidatingWebhook" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -964,7 +983,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a DaemonSet's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DaemonSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentNumberScheduled" = mkOption {
           description = "The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/";
@@ -1195,7 +1214,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a deployment's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DeploymentCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "observedGeneration" = mkOption {
           description = "The generation observed by the deployment controller.";
@@ -1388,7 +1407,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replica set's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.ReplicaSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
           description = "The number of pods that have labels matching the labels of the pod template of the replicaset.";
@@ -1622,7 +1641,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a statefulset's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.StatefulSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentReplicas" = mkOption {
           description = "currentReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by currentRevision.";
@@ -4170,7 +4189,7 @@ let
         "conditions" = mkOption {
           description = "The latest available observations of an object's current state. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.batch.v1.JobCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "failed" = mkOption {
           description = "The number of pods which reached phase Failed.";
@@ -5495,7 +5514,7 @@ let
         "conditions" = mkOption {
           description = "List of component conditions observed";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ComponentCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "kind" = mkOption {
           description = "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds";
@@ -5759,7 +5778,7 @@ let
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "envFrom" = mkOption {
           description = "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.";
@@ -5788,7 +5807,7 @@ let
         "ports" = mkOption {
           description = "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "readinessProbe" = mkOption {
           description = "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes";
@@ -5829,12 +5848,12 @@ let
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "workingDir" = mkOption {
           description = "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.";
@@ -6407,7 +6426,7 @@ let
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "envFrom" = mkOption {
           description = "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.";
@@ -6480,12 +6499,12 @@ let
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "workingDir" = mkOption {
           description = "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.";
@@ -7547,7 +7566,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a namespace's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NamespaceCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "phase" = mkOption {
           description = "Phase is the current lifecycle phase of the namespace. More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/";
@@ -7868,7 +7887,7 @@ let
         "addresses" = mkOption {
           description = "List of addresses reachable to the node. Queried from cloud provider, if available. More info: https://kubernetes.io/docs/concepts/nodes/node/#addresses Note: This field is declared as mergeable, but the merge key is not sufficiently unique, which can cause data corruption when it is merged. Callers should instead use a full-replacement patch. See http://pr.k8s.io/79391 for an example.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeAddress" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "allocatable" = mkOption {
           description = "Allocatable represents the resources of a node that are available for scheduling. Defaults to Capacity.";
@@ -7881,7 +7900,7 @@ let
         "conditions" = mkOption {
           description = "Conditions is an array of current observed node conditions. More info: https://kubernetes.io/docs/concepts/nodes/node/#condition";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "config" = mkOption {
           description = "Status of the config assigned to the node via the dynamic Kubelet config feature.";
@@ -8238,7 +8257,7 @@ let
         "conditions" = mkOption {
           description = "Current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PersistentVolumeClaimCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "phase" = mkOption {
           description = "Phase represents the current phase of PersistentVolumeClaim.";
@@ -8843,7 +8862,7 @@ let
         "containers" = mkOption {
           description = "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.";
           type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name");
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "dnsConfig" = mkOption {
           description = "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.";
@@ -8860,12 +8879,12 @@ let
         "ephemeralContainers" = mkOption {
           description = "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "hostAliases" = mkOption {
           description = "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HostAlias" "ip"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "hostIPC" = mkOption {
           description = "Use the host's ipc namespace. Optional: Default to false.";
@@ -8886,12 +8905,12 @@ let
         "imagePullSecrets" = mkOption {
           description = "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "initContainers" = mkOption {
           description = "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "nodeName" = mkOption {
           description = "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.";
@@ -8968,12 +8987,12 @@ let
         "topologySpreadConstraints" = mkOption {
           description = "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.TopologySpreadConstraint" "topologyKey"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumes" = mkOption {
           description = "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Volume" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -9022,7 +9041,7 @@ let
         "conditions" = mkOption {
           description = "Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "containerStatuses" = mkOption {
           description = "The list has one entry per container in the manifest. Each entry is currently the output of `docker inspect`. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status";
@@ -9059,7 +9078,7 @@ let
         "podIPs" = mkOption {
           description = "podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list is empty if no IPs have been allocated yet.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodIP" "ip"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "qosClass" = mkOption {
           description = "The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md";
@@ -9553,7 +9572,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replication controller's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ReplicationControllerCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
           description = "The number of pods that have labels matching the labels of the pod template of the replication controller.";
@@ -10256,7 +10275,7 @@ let
         "secrets" = mkOption {
           description = "Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: https://kubernetes.io/docs/concepts/configuration/secret";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -10430,7 +10449,7 @@ let
         "ports" = mkOption {
           description = "The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ServicePort" "port"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "publishNotReadyAddresses" = mkOption {
           description = "publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered \"ready\" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.";
@@ -15338,7 +15357,7 @@ let
         "drivers" = mkOption {
           description = "drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.";
           type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1.CSINodeDriver" "name");
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -15940,7 +15959,7 @@ let
         "drivers" = mkOption {
           description = "drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.";
           type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1beta1.CSINodeDriver" "name");
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -17972,7 +17991,7 @@ let
         "ownerReferences" = mkOption {
           description = "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference" "uid"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "resourceVersion" = mkOption {
           description = "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency";
@@ -18409,7 +18428,7 @@ let
         "conditions" = mkOption {
           description = "Current service state of apiService.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -18590,7 +18609,7 @@ let
         "conditions" = mkOption {
           description = "Current service state of apiService.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 

--- a/modules/generated/v1.21.nix
+++ b/modules/generated/v1.21.nix
@@ -4,6 +4,21 @@
 with lib;
 
 let
+  hasAttrNotNull = attr: set: hasAttr attr set && !isNull set.${attr};
+
+  attrsToList = values:
+    if values != null
+    then
+      sort
+        (a: b:
+          if (hasAttrNotNull "_priority" a && hasAttrNotNull "_priority" b)
+          then a._priority < b._priority
+          else false
+        )
+        (mapAttrsToList (n: v: v) values)
+    else
+      values;
+
   getDefaults = resource: group: version: kind:
     catAttrs "default" (filter
       (default:
@@ -51,15 +66,16 @@ let
 
   mkOptionDefault = mkOverride 1001;
 
+  # todo: can we use mkOrder
   mergeValuesByKey = mergeKey: values:
-    listToAttrs (map
-      (value: nameValuePair
+    listToAttrs (imap0
+      (i: value: nameValuePair
         (
           if isAttrs value.${mergeKey}
           then toString value.${mergeKey}.content
           else (toString value.${mergeKey})
         )
-        value)
+        (value // { _priority = i; }))
       values);
 
   submoduleOf = ref: types.submodule ({ name, ... }: {
@@ -75,7 +91,10 @@ let
         else name;
     in
     {
-      options = definitions."${ref}".options;
+      options = definitions."${ref}".options // {
+        # position in original array
+        _priority = mkOption { type = types.nullOr types.int; default = null; };
+      };
       config = definitions."${ref}".config // {
         ${mergeKey} = mkOverride 1002 (convertName name);
       };
@@ -186,7 +205,7 @@ let
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.MutatingWebhook" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -365,7 +384,7 @@ let
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.ValidatingWebhook" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -513,7 +532,7 @@ let
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1beta1.MutatingWebhook" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -694,7 +713,7 @@ let
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1beta1.ValidatingWebhook" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -1114,7 +1133,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a DaemonSet's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DaemonSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentNumberScheduled" = mkOption {
           description = "The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/";
@@ -1345,7 +1364,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a deployment's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DeploymentCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "observedGeneration" = mkOption {
           description = "The generation observed by the deployment controller.";
@@ -1538,7 +1557,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replica set's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.ReplicaSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
           description = "The number of pods that have labels matching the labels of the pod template of the replicaset.";
@@ -1777,7 +1796,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a statefulset's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.StatefulSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentReplicas" = mkOption {
           description = "currentReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by currentRevision.";
@@ -4588,7 +4607,7 @@ let
         "conditions" = mkOption {
           description = "The latest available observations of an object's current state. When a Job fails, one of the conditions will have type \"Failed\" and status true. When a Job is suspended, one of the conditions will have type \"Suspended\" and status true; when the Job is resumed, the status of this condition will become false. When a Job is completed, one of the conditions will have type \"Complete\" and status true. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.batch.v1.JobCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "failed" = mkOption {
           description = "The number of pods which reached phase Failed.";
@@ -5792,7 +5811,7 @@ let
         "conditions" = mkOption {
           description = "List of component conditions observed";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ComponentCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "kind" = mkOption {
           description = "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds";
@@ -6056,7 +6075,7 @@ let
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "envFrom" = mkOption {
           description = "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.";
@@ -6085,7 +6104,7 @@ let
         "ports" = mkOption {
           description = "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "readinessProbe" = mkOption {
           description = "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes";
@@ -6126,12 +6145,12 @@ let
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "workingDir" = mkOption {
           description = "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.";
@@ -6704,7 +6723,7 @@ let
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "envFrom" = mkOption {
           description = "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.";
@@ -6777,12 +6796,12 @@ let
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "workingDir" = mkOption {
           description = "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.";
@@ -6827,7 +6846,7 @@ let
         "ephemeralContainers" = mkOption {
           description = "A list of ephemeral containers associated with this pod. New ephemeral containers may be appended to this list, but existing ephemeral containers may not be removed or modified.";
           type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name");
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "kind" = mkOption {
           description = "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds";
@@ -7874,7 +7893,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a namespace's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NamespaceCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "phase" = mkOption {
           description = "Phase is the current lifecycle phase of the namespace. More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/";
@@ -8195,7 +8214,7 @@ let
         "addresses" = mkOption {
           description = "List of addresses reachable to the node. Queried from cloud provider, if available. More info: https://kubernetes.io/docs/concepts/nodes/node/#addresses Note: This field is declared as mergeable, but the merge key is not sufficiently unique, which can cause data corruption when it is merged. Callers should instead use a full-replacement patch. See http://pr.k8s.io/79391 for an example.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeAddress" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "allocatable" = mkOption {
           description = "Allocatable represents the resources of a node that are available for scheduling. Defaults to Capacity.";
@@ -8208,7 +8227,7 @@ let
         "conditions" = mkOption {
           description = "Conditions is an array of current observed node conditions. More info: https://kubernetes.io/docs/concepts/nodes/node/#condition";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "config" = mkOption {
           description = "Status of the config assigned to the node via the dynamic Kubelet config feature.";
@@ -8565,7 +8584,7 @@ let
         "conditions" = mkOption {
           description = "Current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PersistentVolumeClaimCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "phase" = mkOption {
           description = "Phase represents the current phase of PersistentVolumeClaim.";
@@ -9175,7 +9194,7 @@ let
         "containers" = mkOption {
           description = "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.";
           type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name");
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "dnsConfig" = mkOption {
           description = "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.";
@@ -9192,12 +9211,12 @@ let
         "ephemeralContainers" = mkOption {
           description = "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "hostAliases" = mkOption {
           description = "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HostAlias" "ip"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "hostIPC" = mkOption {
           description = "Use the host's ipc namespace. Optional: Default to false.";
@@ -9218,12 +9237,12 @@ let
         "imagePullSecrets" = mkOption {
           description = "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "initContainers" = mkOption {
           description = "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "nodeName" = mkOption {
           description = "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.";
@@ -9300,12 +9319,12 @@ let
         "topologySpreadConstraints" = mkOption {
           description = "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.TopologySpreadConstraint" "topologyKey"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumes" = mkOption {
           description = "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Volume" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -9354,7 +9373,7 @@ let
         "conditions" = mkOption {
           description = "Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "containerStatuses" = mkOption {
           description = "The list has one entry per container in the manifest. Each entry is currently the output of `docker inspect`. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status";
@@ -9391,7 +9410,7 @@ let
         "podIPs" = mkOption {
           description = "podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list is empty if no IPs have been allocated yet.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodIP" "ip"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "qosClass" = mkOption {
           description = "The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md";
@@ -9914,7 +9933,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replication controller's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ReplicationControllerCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
           description = "The number of pods that have labels matching the labels of the pod template of the replication controller.";
@@ -10617,7 +10636,7 @@ let
         "secrets" = mkOption {
           description = "Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: https://kubernetes.io/docs/concepts/configuration/secret";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -10811,7 +10830,7 @@ let
         "ports" = mkOption {
           description = "The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ServicePort" "port"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "publishNotReadyAddresses" = mkOption {
           description = "publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered \"ready\" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.";
@@ -10870,7 +10889,7 @@ let
         "conditions" = mkOption {
           description = "Current service state";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "loadBalancer" = mkOption {
           description = "LoadBalancer contains the current status of the load-balancer, if one is present.";
@@ -14171,7 +14190,7 @@ let
         "conditions" = mkOption {
           description = "Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute\n              the number of allowed disruptions. Therefore no disruptions are\n              allowed and the status of the condition will be False.\n- InsufficientPods: The number of pods are either at or below the number\n                    required by the PodDisruptionBudget. No disruptions are\n                    allowed and the status of the condition will be False.\n- SufficientPods: There are more pods than required by the PodDisruptionBudget.\n                  The condition will be True, and the number of allowed\n                  disruptions are provided by the disruptionsAllowed property.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentHealthy" = mkOption {
           description = "current number of healthy pods";
@@ -14432,7 +14451,7 @@ let
         "conditions" = mkOption {
           description = "Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute\n              the number of allowed disruptions. Therefore no disruptions are\n              allowed and the status of the condition will be False.\n- InsufficientPods: The number of pods are either at or below the number\n                    required by the PodDisruptionBudget. No disruptions are\n                    allowed and the status of the condition will be False.\n- SufficientPods: There are more pods than required by the PodDisruptionBudget.\n                  The condition will be True, and the number of allowed\n                  disruptions are provided by the disruptionsAllowed property.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentHealthy" = mkOption {
           description = "current number of healthy pods";
@@ -16204,7 +16223,7 @@ let
         "drivers" = mkOption {
           description = "drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.";
           type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1.CSINodeDriver" "name");
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -16908,7 +16927,7 @@ let
         "drivers" = mkOption {
           description = "drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.";
           type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1beta1.CSINodeDriver" "name");
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -19067,7 +19086,7 @@ let
         "ownerReferences" = mkOption {
           description = "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference" "uid"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "resourceVersion" = mkOption {
           description = "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency";
@@ -19504,7 +19523,7 @@ let
         "conditions" = mkOption {
           description = "Current service state of apiService.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -19685,7 +19704,7 @@ let
         "conditions" = mkOption {
           description = "Current service state of apiService.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 

--- a/modules/generated/v1.22.nix
+++ b/modules/generated/v1.22.nix
@@ -4,6 +4,21 @@
 with lib;
 
 let
+  hasAttrNotNull = attr: set: hasAttr attr set && !isNull set.${attr};
+
+  attrsToList = values:
+    if values != null
+    then
+      sort
+        (a: b:
+          if (hasAttrNotNull "_priority" a && hasAttrNotNull "_priority" b)
+          then a._priority < b._priority
+          else false
+        )
+        (mapAttrsToList (n: v: v) values)
+    else
+      values;
+
   getDefaults = resource: group: version: kind:
     catAttrs "default" (filter
       (default:
@@ -51,15 +66,16 @@ let
 
   mkOptionDefault = mkOverride 1001;
 
+  # todo: can we use mkOrder
   mergeValuesByKey = mergeKey: values:
-    listToAttrs (map
-      (value: nameValuePair
+    listToAttrs (imap0
+      (i: value: nameValuePair
         (
           if isAttrs value.${mergeKey}
           then toString value.${mergeKey}.content
           else (toString value.${mergeKey})
         )
-        value)
+        (value // { _priority = i; }))
       values);
 
   submoduleOf = ref: types.submodule ({ name, ... }: {
@@ -75,7 +91,10 @@ let
         else name;
     in
     {
-      options = definitions."${ref}".options;
+      options = definitions."${ref}".options // {
+        # position in original array
+        _priority = mkOption { type = types.nullOr types.int; default = null; };
+      };
       config = definitions."${ref}".config // {
         ${mergeKey} = mkOverride 1002 (convertName name);
       };
@@ -186,7 +205,7 @@ let
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.MutatingWebhook" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -365,7 +384,7 @@ let
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.ValidatingWebhook" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -785,7 +804,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a DaemonSet's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DaemonSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentNumberScheduled" = mkOption {
           description = "The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/";
@@ -1016,7 +1035,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a deployment's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DeploymentCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "observedGeneration" = mkOption {
           description = "The generation observed by the deployment controller.";
@@ -1209,7 +1228,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replica set's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.ReplicaSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
           description = "The number of pods that have labels matching the labels of the pod template of the replicaset.";
@@ -1457,7 +1476,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a statefulset's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.StatefulSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentReplicas" = mkOption {
           description = "currentReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by currentRevision.";
@@ -3775,7 +3794,7 @@ let
         "conditions" = mkOption {
           description = "The latest available observations of an object's current state. When a Job fails, one of the conditions will have type \"Failed\" and status true. When a Job is suspended, one of the conditions will have type \"Suspended\" and status true; when the Job is resumed, the status of this condition will become false. When a Job is completed, one of the conditions will have type \"Complete\" and status true. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.batch.v1.JobCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "failed" = mkOption {
           description = "The number of pods which reached phase Failed.";
@@ -4748,7 +4767,7 @@ let
         "conditions" = mkOption {
           description = "List of component conditions observed";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ComponentCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "kind" = mkOption {
           description = "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds";
@@ -5012,7 +5031,7 @@ let
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "envFrom" = mkOption {
           description = "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.";
@@ -5041,7 +5060,7 @@ let
         "ports" = mkOption {
           description = "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "readinessProbe" = mkOption {
           description = "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes";
@@ -5082,12 +5101,12 @@ let
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "workingDir" = mkOption {
           description = "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.";
@@ -5661,7 +5680,7 @@ let
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "envFrom" = mkOption {
           description = "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.";
@@ -5734,12 +5753,12 @@ let
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "workingDir" = mkOption {
           description = "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.";
@@ -6801,7 +6820,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a namespace's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NamespaceCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "phase" = mkOption {
           description = "Phase is the current lifecycle phase of the namespace. More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/";
@@ -7122,7 +7141,7 @@ let
         "addresses" = mkOption {
           description = "List of addresses reachable to the node. Queried from cloud provider, if available. More info: https://kubernetes.io/docs/concepts/nodes/node/#addresses Note: This field is declared as mergeable, but the merge key is not sufficiently unique, which can cause data corruption when it is merged. Callers should instead use a full-replacement patch. See http://pr.k8s.io/79391 for an example.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeAddress" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "allocatable" = mkOption {
           description = "Allocatable represents the resources of a node that are available for scheduling. Defaults to Capacity.";
@@ -7135,7 +7154,7 @@ let
         "conditions" = mkOption {
           description = "Conditions is an array of current observed node conditions. More info: https://kubernetes.io/docs/concepts/nodes/node/#condition";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "config" = mkOption {
           description = "Status of the config assigned to the node via the dynamic Kubelet config feature.";
@@ -7497,7 +7516,7 @@ let
         "conditions" = mkOption {
           description = "Current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PersistentVolumeClaimCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "phase" = mkOption {
           description = "Phase represents the current phase of PersistentVolumeClaim.";
@@ -8107,7 +8126,7 @@ let
         "containers" = mkOption {
           description = "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.";
           type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name");
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "dnsConfig" = mkOption {
           description = "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.";
@@ -8124,12 +8143,12 @@ let
         "ephemeralContainers" = mkOption {
           description = "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "hostAliases" = mkOption {
           description = "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HostAlias" "ip"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "hostIPC" = mkOption {
           description = "Use the host's ipc namespace. Optional: Default to false.";
@@ -8150,12 +8169,12 @@ let
         "imagePullSecrets" = mkOption {
           description = "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "initContainers" = mkOption {
           description = "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "nodeName" = mkOption {
           description = "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.";
@@ -8232,12 +8251,12 @@ let
         "topologySpreadConstraints" = mkOption {
           description = "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.TopologySpreadConstraint" "topologyKey"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumes" = mkOption {
           description = "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Volume" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -8286,7 +8305,7 @@ let
         "conditions" = mkOption {
           description = "Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "containerStatuses" = mkOption {
           description = "The list has one entry per container in the manifest. Each entry is currently the output of `docker inspect`. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status";
@@ -8323,7 +8342,7 @@ let
         "podIPs" = mkOption {
           description = "podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list is empty if no IPs have been allocated yet.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodIP" "ip"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "qosClass" = mkOption {
           description = "The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md";
@@ -8846,7 +8865,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replication controller's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ReplicationControllerCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
           description = "The number of pods that have labels matching the labels of the pod template of the replication controller.";
@@ -9549,7 +9568,7 @@ let
         "secrets" = mkOption {
           description = "Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: https://kubernetes.io/docs/concepts/configuration/secret";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -9743,7 +9762,7 @@ let
         "ports" = mkOption {
           description = "The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ServicePort" "port"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "publishNotReadyAddresses" = mkOption {
           description = "publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered \"ready\" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.";
@@ -9797,7 +9816,7 @@ let
         "conditions" = mkOption {
           description = "Current service state";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "loadBalancer" = mkOption {
           description = "LoadBalancer contains the current status of the load-balancer, if one is present.";
@@ -12598,7 +12617,7 @@ let
         "conditions" = mkOption {
           description = "Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute\n              the number of allowed disruptions. Therefore no disruptions are\n              allowed and the status of the condition will be False.\n- InsufficientPods: The number of pods are either at or below the number\n                    required by the PodDisruptionBudget. No disruptions are\n                    allowed and the status of the condition will be False.\n- SufficientPods: There are more pods than required by the PodDisruptionBudget.\n                  The condition will be True, and the number of allowed\n                  disruptions are provided by the disruptionsAllowed property.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentHealthy" = mkOption {
           description = "current number of healthy pods";
@@ -12829,7 +12848,7 @@ let
         "conditions" = mkOption {
           description = "Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute\n              the number of allowed disruptions. Therefore no disruptions are\n              allowed and the status of the condition will be False.\n- InsufficientPods: The number of pods are either at or below the number\n                    required by the PodDisruptionBudget. No disruptions are\n                    allowed and the status of the condition will be False.\n- SufficientPods: There are more pods than required by the PodDisruptionBudget.\n                  The condition will be True, and the number of allowed\n                  disruptions are provided by the disruptionsAllowed property.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentHealthy" = mkOption {
           description = "current number of healthy pods";
@@ -14181,7 +14200,7 @@ let
         "drivers" = mkOption {
           description = "drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.";
           type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1.CSINodeDriver" "name");
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -15886,7 +15905,7 @@ let
         "ownerReferences" = mkOption {
           description = "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference" "uid"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "resourceVersion" = mkOption {
           description = "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency";
@@ -16323,7 +16342,7 @@ let
         "conditions" = mkOption {
           description = "Current service state of apiService.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 

--- a/modules/generated/v1.23.nix
+++ b/modules/generated/v1.23.nix
@@ -4,6 +4,21 @@
 with lib;
 
 let
+  hasAttrNotNull = attr: set: hasAttr attr set && !isNull set.${attr};
+
+  attrsToList = values:
+    if values != null
+    then
+      sort
+        (a: b:
+          if (hasAttrNotNull "_priority" a && hasAttrNotNull "_priority" b)
+          then a._priority < b._priority
+          else false
+        )
+        (mapAttrsToList (n: v: v) values)
+    else
+      values;
+
   getDefaults = resource: group: version: kind:
     catAttrs "default" (filter
       (default:
@@ -51,15 +66,16 @@ let
 
   mkOptionDefault = mkOverride 1001;
 
+  # todo: can we use mkOrder
   mergeValuesByKey = mergeKey: values:
-    listToAttrs (map
-      (value: nameValuePair
+    listToAttrs (imap0
+      (i: value: nameValuePair
         (
           if isAttrs value.${mergeKey}
           then toString value.${mergeKey}.content
           else (toString value.${mergeKey})
         )
-        value)
+        (value // { _priority = i; }))
       values);
 
   submoduleOf = ref: types.submodule ({ name, ... }: {
@@ -75,7 +91,10 @@ let
         else name;
     in
     {
-      options = definitions."${ref}".options;
+      options = definitions."${ref}".options // {
+        # position in original array
+        _priority = mkOption { type = types.nullOr types.int; default = null; };
+      };
       config = definitions."${ref}".config // {
         ${mergeKey} = mkOverride 1002 (convertName name);
       };
@@ -186,7 +205,7 @@ let
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.MutatingWebhook" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -365,7 +384,7 @@ let
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.ValidatingWebhook" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -785,7 +804,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a DaemonSet's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DaemonSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentNumberScheduled" = mkOption {
           description = "The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/";
@@ -1016,7 +1035,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a deployment's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DeploymentCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "observedGeneration" = mkOption {
           description = "The generation observed by the deployment controller.";
@@ -1209,7 +1228,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replica set's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.ReplicaSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
           description = "The number of pods that have labels matching the labels of the pod template of the replicaset.";
@@ -1482,7 +1501,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a statefulset's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.StatefulSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentReplicas" = mkOption {
           description = "currentReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by currentRevision.";
@@ -2665,7 +2684,7 @@ let
         "conditions" = mkOption {
           description = "conditions is the set of conditions required for this autoscaler to scale its target, and indicates whether or not those conditions are met.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentMetrics" = mkOption {
           description = "currentMetrics is the last read state of the metrics used by this autoscaler.";
@@ -4398,7 +4417,7 @@ let
         "conditions" = mkOption {
           description = "The latest available observations of an object's current state. When a Job fails, one of the conditions will have type \"Failed\" and status true. When a Job is suspended, one of the conditions will have type \"Suspended\" and status true; when the Job is resumed, the status of this condition will become false. When a Job is completed, one of the conditions will have type \"Complete\" and status true. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.batch.v1.JobCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "failed" = mkOption {
           description = "The number of pods which reached phase Failed.";
@@ -5376,7 +5395,7 @@ let
         "conditions" = mkOption {
           description = "List of component conditions observed";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ComponentCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "kind" = mkOption {
           description = "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds";
@@ -5640,7 +5659,7 @@ let
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "envFrom" = mkOption {
           description = "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.";
@@ -5669,7 +5688,7 @@ let
         "ports" = mkOption {
           description = "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "readinessProbe" = mkOption {
           description = "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes";
@@ -5710,12 +5729,12 @@ let
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "workingDir" = mkOption {
           description = "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.";
@@ -6289,7 +6308,7 @@ let
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "envFrom" = mkOption {
           description = "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.";
@@ -6318,7 +6337,7 @@ let
         "ports" = mkOption {
           description = "Ports are not allowed for ephemeral containers.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "readinessProbe" = mkOption {
           description = "Probes are not allowed for ephemeral containers.";
@@ -6363,12 +6382,12 @@ let
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "workingDir" = mkOption {
           description = "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.";
@@ -7449,7 +7468,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a namespace's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NamespaceCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "phase" = mkOption {
           description = "Phase is the current lifecycle phase of the namespace. More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/\n\n";
@@ -7770,7 +7789,7 @@ let
         "addresses" = mkOption {
           description = "List of addresses reachable to the node. Queried from cloud provider, if available. More info: https://kubernetes.io/docs/concepts/nodes/node/#addresses Note: This field is declared as mergeable, but the merge key is not sufficiently unique, which can cause data corruption when it is merged. Callers should instead use a full-replacement patch. See http://pr.k8s.io/79391 for an example.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeAddress" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "allocatable" = mkOption {
           description = "Allocatable represents the resources of a node that are available for scheduling. Defaults to Capacity.";
@@ -7783,7 +7802,7 @@ let
         "conditions" = mkOption {
           description = "Conditions is an array of current observed node conditions. More info: https://kubernetes.io/docs/concepts/nodes/node/#condition";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "config" = mkOption {
           description = "Status of the config assigned to the node via the dynamic Kubelet config feature.";
@@ -8149,7 +8168,7 @@ let
         "conditions" = mkOption {
           description = "Current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PersistentVolumeClaimCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "phase" = mkOption {
           description = "Phase represents the current phase of PersistentVolumeClaim.\n\n";
@@ -8778,7 +8797,7 @@ let
         "containers" = mkOption {
           description = "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.";
           type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name");
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "dnsConfig" = mkOption {
           description = "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.";
@@ -8795,12 +8814,12 @@ let
         "ephemeralContainers" = mkOption {
           description = "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is beta-level and available on clusters that haven't disabled the EphemeralContainers feature gate.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "hostAliases" = mkOption {
           description = "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HostAlias" "ip"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "hostIPC" = mkOption {
           description = "Use the host's ipc namespace. Optional: Default to false.";
@@ -8821,12 +8840,12 @@ let
         "imagePullSecrets" = mkOption {
           description = "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "initContainers" = mkOption {
           description = "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "nodeName" = mkOption {
           description = "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.";
@@ -8907,12 +8926,12 @@ let
         "topologySpreadConstraints" = mkOption {
           description = "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.TopologySpreadConstraint" "topologyKey"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumes" = mkOption {
           description = "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Volume" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -8962,7 +8981,7 @@ let
         "conditions" = mkOption {
           description = "Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "containerStatuses" = mkOption {
           description = "The list has one entry per container in the manifest. Each entry is currently the output of `docker inspect`. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status";
@@ -8999,7 +9018,7 @@ let
         "podIPs" = mkOption {
           description = "podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list is empty if no IPs have been allocated yet.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodIP" "ip"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "qosClass" = mkOption {
           description = "The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md\n\n";
@@ -9527,7 +9546,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replication controller's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ReplicationControllerCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
           description = "The number of pods that have labels matching the labels of the pod template of the replication controller.";
@@ -10230,7 +10249,7 @@ let
         "secrets" = mkOption {
           description = "Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: https://kubernetes.io/docs/concepts/configuration/secret";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -10424,7 +10443,7 @@ let
         "ports" = mkOption {
           description = "The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ServicePort" "port"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "publishNotReadyAddresses" = mkOption {
           description = "publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered \"ready\" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.";
@@ -10478,7 +10497,7 @@ let
         "conditions" = mkOption {
           description = "Current service state";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "loadBalancer" = mkOption {
           description = "LoadBalancer contains the current status of the load-balancer, if one is present.";
@@ -13790,7 +13809,7 @@ let
         "conditions" = mkOption {
           description = "Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute\n              the number of allowed disruptions. Therefore no disruptions are\n              allowed and the status of the condition will be False.\n- InsufficientPods: The number of pods are either at or below the number\n                    required by the PodDisruptionBudget. No disruptions are\n                    allowed and the status of the condition will be False.\n- SufficientPods: There are more pods than required by the PodDisruptionBudget.\n                  The condition will be True, and the number of allowed\n                  disruptions are provided by the disruptionsAllowed property.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentHealthy" = mkOption {
           description = "current number of healthy pods";
@@ -14021,7 +14040,7 @@ let
         "conditions" = mkOption {
           description = "Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute\n              the number of allowed disruptions. Therefore no disruptions are\n              allowed and the status of the condition will be False.\n- InsufficientPods: The number of pods are either at or below the number\n                    required by the PodDisruptionBudget. No disruptions are\n                    allowed and the status of the condition will be False.\n- SufficientPods: There are more pods than required by the PodDisruptionBudget.\n                  The condition will be True, and the number of allowed\n                  disruptions are provided by the disruptionsAllowed property.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentHealthy" = mkOption {
           description = "current number of healthy pods";
@@ -14953,7 +14972,7 @@ let
         "drivers" = mkOption {
           description = "drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.";
           type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1.CSINodeDriver" "name");
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -15938,7 +15957,7 @@ let
         "x-kubernetes-validations" = mkOption {
           description = "x-kubernetes-validations describes a list of validation rules written in the CEL expression language. This field is an alpha-level. Using this field requires the feature gate `CustomResourceValidationExpressions` to be enabled.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule" "rule"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -16530,7 +16549,7 @@ let
         "ownerReferences" = mkOption {
           description = "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference" "uid"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "resourceVersion" = mkOption {
           description = "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency";
@@ -16967,7 +16986,7 @@ let
         "conditions" = mkOption {
           description = "Current service state of apiService.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 

--- a/modules/generated/v1.24.nix
+++ b/modules/generated/v1.24.nix
@@ -4,6 +4,21 @@
 with lib;
 
 let
+  hasAttrNotNull = attr: set: hasAttr attr set && !isNull set.${attr};
+
+  attrsToList = values:
+    if values != null
+    then
+      sort
+        (a: b:
+          if (hasAttrNotNull "_priority" a && hasAttrNotNull "_priority" b)
+          then a._priority < b._priority
+          else false
+        )
+        (mapAttrsToList (n: v: v) values)
+    else
+      values;
+
   getDefaults = resource: group: version: kind:
     catAttrs "default" (filter
       (default:
@@ -51,15 +66,16 @@ let
 
   mkOptionDefault = mkOverride 1001;
 
+  # todo: can we use mkOrder
   mergeValuesByKey = mergeKey: values:
-    listToAttrs (map
-      (value: nameValuePair
+    listToAttrs (imap0
+      (i: value: nameValuePair
         (
           if isAttrs value.${mergeKey}
           then toString value.${mergeKey}.content
           else (toString value.${mergeKey})
         )
-        value)
+        (value // { _priority = i; }))
       values);
 
   submoduleOf = ref: types.submodule ({ name, ... }: {
@@ -75,7 +91,10 @@ let
         else name;
     in
     {
-      options = definitions."${ref}".options;
+      options = definitions."${ref}".options // {
+        # position in original array
+        _priority = mkOption { type = types.nullOr types.int; default = null; };
+      };
       config = definitions."${ref}".config // {
         ${mergeKey} = mkOverride 1002 (convertName name);
       };
@@ -186,7 +205,7 @@ let
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.MutatingWebhook" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -365,7 +384,7 @@ let
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.ValidatingWebhook" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -785,7 +804,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a DaemonSet's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DaemonSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentNumberScheduled" = mkOption {
           description = "The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/";
@@ -1016,7 +1035,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a deployment's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DeploymentCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "observedGeneration" = mkOption {
           description = "The generation observed by the deployment controller.";
@@ -1209,7 +1228,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replica set's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.ReplicaSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
           description = "The number of pods that have labels matching the labels of the pod template of the replicaset.";
@@ -1487,7 +1506,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a statefulset's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.StatefulSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentReplicas" = mkOption {
           description = "currentReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by currentRevision.";
@@ -2670,7 +2689,7 @@ let
         "conditions" = mkOption {
           description = "conditions is the set of conditions required for this autoscaler to scale its target, and indicates whether or not those conditions are met.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentMetrics" = mkOption {
           description = "currentMetrics is the last read state of the metrics used by this autoscaler.";
@@ -4408,7 +4427,7 @@ let
         "conditions" = mkOption {
           description = "The latest available observations of an object's current state. When a Job fails, one of the conditions will have type \"Failed\" and status true. When a Job is suspended, one of the conditions will have type \"Suspended\" and status true; when the Job is resumed, the status of this condition will become false. When a Job is completed, one of the conditions will have type \"Complete\" and status true. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.batch.v1.JobCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "failed" = mkOption {
           description = "The number of pods which reached phase Failed.";
@@ -5391,7 +5410,7 @@ let
         "conditions" = mkOption {
           description = "List of component conditions observed";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ComponentCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "kind" = mkOption {
           description = "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds";
@@ -5655,7 +5674,7 @@ let
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "envFrom" = mkOption {
           description = "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.";
@@ -5684,7 +5703,7 @@ let
         "ports" = mkOption {
           description = "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "readinessProbe" = mkOption {
           description = "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes";
@@ -5725,12 +5744,12 @@ let
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "workingDir" = mkOption {
           description = "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.";
@@ -6304,7 +6323,7 @@ let
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "envFrom" = mkOption {
           description = "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.";
@@ -6333,7 +6352,7 @@ let
         "ports" = mkOption {
           description = "Ports are not allowed for ephemeral containers.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "readinessProbe" = mkOption {
           description = "Probes are not allowed for ephemeral containers.";
@@ -6378,12 +6397,12 @@ let
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "workingDir" = mkOption {
           description = "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.";
@@ -7464,7 +7483,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a namespace's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NamespaceCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "phase" = mkOption {
           description = "Phase is the current lifecycle phase of the namespace. More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/\n\n";
@@ -7785,7 +7804,7 @@ let
         "addresses" = mkOption {
           description = "List of addresses reachable to the node. Queried from cloud provider, if available. More info: https://kubernetes.io/docs/concepts/nodes/node/#addresses Note: This field is declared as mergeable, but the merge key is not sufficiently unique, which can cause data corruption when it is merged. Callers should instead use a full-replacement patch. See http://pr.k8s.io/79391 for an example.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeAddress" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "allocatable" = mkOption {
           description = "Allocatable represents the resources of a node that are available for scheduling. Defaults to Capacity.";
@@ -7798,7 +7817,7 @@ let
         "conditions" = mkOption {
           description = "Conditions is an array of current observed node conditions. More info: https://kubernetes.io/docs/concepts/nodes/node/#condition";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "config" = mkOption {
           description = "Status of the config assigned to the node via the dynamic Kubelet config feature.";
@@ -8164,7 +8183,7 @@ let
         "conditions" = mkOption {
           description = "conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PersistentVolumeClaimCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "phase" = mkOption {
           description = "phase represents the current phase of PersistentVolumeClaim.\n\n";
@@ -8793,7 +8812,7 @@ let
         "containers" = mkOption {
           description = "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.";
           type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name");
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "dnsConfig" = mkOption {
           description = "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.";
@@ -8810,12 +8829,12 @@ let
         "ephemeralContainers" = mkOption {
           description = "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is beta-level and available on clusters that haven't disabled the EphemeralContainers feature gate.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "hostAliases" = mkOption {
           description = "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HostAlias" "ip"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "hostIPC" = mkOption {
           description = "Use the host's ipc namespace. Optional: Default to false.";
@@ -8836,12 +8855,12 @@ let
         "imagePullSecrets" = mkOption {
           description = "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "initContainers" = mkOption {
           description = "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "nodeName" = mkOption {
           description = "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.";
@@ -8922,12 +8941,12 @@ let
         "topologySpreadConstraints" = mkOption {
           description = "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.TopologySpreadConstraint" "topologyKey"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumes" = mkOption {
           description = "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Volume" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -8977,7 +8996,7 @@ let
         "conditions" = mkOption {
           description = "Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "containerStatuses" = mkOption {
           description = "The list has one entry per container in the manifest. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status";
@@ -9014,7 +9033,7 @@ let
         "podIPs" = mkOption {
           description = "podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list is empty if no IPs have been allocated yet.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodIP" "ip"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "qosClass" = mkOption {
           description = "The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md\n\n";
@@ -9542,7 +9561,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replication controller's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ReplicationControllerCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
           description = "The number of pods that have labels matching the labels of the pod template of the replication controller.";
@@ -10245,7 +10264,7 @@ let
         "secrets" = mkOption {
           description = "Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use. Pods are only limited to this list if this service account has a \"kubernetes.io/enforce-mountable-secrets\" annotation set to \"true\". This field should not be used to find auto-generated service account token secrets for use outside of pods. Instead, tokens can be requested directly using the TokenRequest API, or service account token secrets can be manually created. More info: https://kubernetes.io/docs/concepts/configuration/secret";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -10439,7 +10458,7 @@ let
         "ports" = mkOption {
           description = "The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ServicePort" "port"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "publishNotReadyAddresses" = mkOption {
           description = "publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered \"ready\" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.";
@@ -10493,7 +10512,7 @@ let
         "conditions" = mkOption {
           description = "Current service state";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "loadBalancer" = mkOption {
           description = "LoadBalancer contains the current status of the load-balancer, if one is present.";
@@ -13353,7 +13372,7 @@ let
         "conditions" = mkOption {
           description = "Conditions holds an array of metav1.Condition that describe the state of the NetworkPolicy. Current service state";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -13714,7 +13733,7 @@ let
         "conditions" = mkOption {
           description = "Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute\n              the number of allowed disruptions. Therefore no disruptions are\n              allowed and the status of the condition will be False.\n- InsufficientPods: The number of pods are either at or below the number\n                    required by the PodDisruptionBudget. No disruptions are\n                    allowed and the status of the condition will be False.\n- SufficientPods: There are more pods than required by the PodDisruptionBudget.\n                  The condition will be True, and the number of allowed\n                  disruptions are provided by the disruptionsAllowed property.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentHealthy" = mkOption {
           description = "current number of healthy pods";
@@ -13945,7 +13964,7 @@ let
         "conditions" = mkOption {
           description = "Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute\n              the number of allowed disruptions. Therefore no disruptions are\n              allowed and the status of the condition will be False.\n- InsufficientPods: The number of pods are either at or below the number\n                    required by the PodDisruptionBudget. No disruptions are\n                    allowed and the status of the condition will be False.\n- SufficientPods: There are more pods than required by the PodDisruptionBudget.\n                  The condition will be True, and the number of allowed\n                  disruptions are provided by the disruptionsAllowed property.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentHealthy" = mkOption {
           description = "current number of healthy pods";
@@ -14877,7 +14896,7 @@ let
         "drivers" = mkOption {
           description = "drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.";
           type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1.CSINodeDriver" "name");
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -15862,7 +15881,7 @@ let
         "x-kubernetes-validations" = mkOption {
           description = "x-kubernetes-validations describes a list of validation rules written in the CEL expression language. This field is an alpha-level. Using this field requires the feature gate `CustomResourceValidationExpressions` to be enabled.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule" "rule"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -16454,7 +16473,7 @@ let
         "ownerReferences" = mkOption {
           description = "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference" "uid"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "resourceVersion" = mkOption {
           description = "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency";
@@ -16891,7 +16910,7 @@ let
         "conditions" = mkOption {
           description = "Current service state of apiService.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 

--- a/modules/generated/v1.25.nix
+++ b/modules/generated/v1.25.nix
@@ -4,6 +4,21 @@
 with lib;
 
 let
+  hasAttrNotNull = attr: set: hasAttr attr set && !isNull set.${attr};
+
+  attrsToList = values:
+    if values != null
+    then
+      sort
+        (a: b:
+          if (hasAttrNotNull "_priority" a && hasAttrNotNull "_priority" b)
+          then a._priority < b._priority
+          else false
+        )
+        (mapAttrsToList (n: v: v) values)
+    else
+      values;
+
   getDefaults = resource: group: version: kind:
     catAttrs "default" (filter
       (default:
@@ -51,15 +66,16 @@ let
 
   mkOptionDefault = mkOverride 1001;
 
+  # todo: can we use mkOrder
   mergeValuesByKey = mergeKey: values:
-    listToAttrs (map
-      (value: nameValuePair
+    listToAttrs (imap0
+      (i: value: nameValuePair
         (
           if isAttrs value.${mergeKey}
           then toString value.${mergeKey}.content
           else (toString value.${mergeKey})
         )
-        value)
+        (value // { _priority = i; }))
       values);
 
   submoduleOf = ref: types.submodule ({ name, ... }: {
@@ -75,7 +91,10 @@ let
         else name;
     in
     {
-      options = definitions."${ref}".options;
+      options = definitions."${ref}".options // {
+        # position in original array
+        _priority = mkOption { type = types.nullOr types.int; default = null; };
+      };
       config = definitions."${ref}".config // {
         ${mergeKey} = mkOverride 1002 (convertName name);
       };
@@ -186,7 +205,7 @@ let
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.MutatingWebhook" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -365,7 +384,7 @@ let
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.ValidatingWebhook" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -785,7 +804,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a DaemonSet's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DaemonSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentNumberScheduled" = mkOption {
           description = "The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/";
@@ -1016,7 +1035,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a deployment's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DeploymentCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "observedGeneration" = mkOption {
           description = "The generation observed by the deployment controller.";
@@ -1209,7 +1228,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replica set's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.ReplicaSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
           description = "The number of pods that have labels matching the labels of the pod template of the replicaset.";
@@ -1487,7 +1506,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a statefulset's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.StatefulSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentReplicas" = mkOption {
           description = "currentReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by currentRevision.";
@@ -2670,7 +2689,7 @@ let
         "conditions" = mkOption {
           description = "conditions is the set of conditions required for this autoscaler to scale its target, and indicates whether or not those conditions are met.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentMetrics" = mkOption {
           description = "currentMetrics is the last read state of the metrics used by this autoscaler.";
@@ -3880,7 +3899,7 @@ let
         "conditions" = mkOption {
           description = "The latest available observations of an object's current state. When a Job fails, one of the conditions will have type \"Failed\" and status true. When a Job is suspended, one of the conditions will have type \"Suspended\" and status true; when the Job is resumed, the status of this condition will become false. When a Job is completed, one of the conditions will have type \"Complete\" and status true. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.batch.v1.JobCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "failed" = mkOption {
           description = "The number of pods which reached phase Failed.";
@@ -4787,7 +4806,7 @@ let
         "conditions" = mkOption {
           description = "List of component conditions observed";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ComponentCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "kind" = mkOption {
           description = "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds";
@@ -5051,7 +5070,7 @@ let
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "envFrom" = mkOption {
           description = "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.";
@@ -5080,7 +5099,7 @@ let
         "ports" = mkOption {
           description = "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "readinessProbe" = mkOption {
           description = "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes";
@@ -5121,12 +5140,12 @@ let
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "workingDir" = mkOption {
           description = "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.";
@@ -5700,7 +5719,7 @@ let
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "envFrom" = mkOption {
           description = "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.";
@@ -5729,7 +5748,7 @@ let
         "ports" = mkOption {
           description = "Ports are not allowed for ephemeral containers.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "readinessProbe" = mkOption {
           description = "Probes are not allowed for ephemeral containers.";
@@ -5774,12 +5793,12 @@ let
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "workingDir" = mkOption {
           description = "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.";
@@ -6860,7 +6879,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a namespace's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NamespaceCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "phase" = mkOption {
           description = "Phase is the current lifecycle phase of the namespace. More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/\n\n";
@@ -7181,7 +7200,7 @@ let
         "addresses" = mkOption {
           description = "List of addresses reachable to the node. Queried from cloud provider, if available. More info: https://kubernetes.io/docs/concepts/nodes/node/#addresses Note: This field is declared as mergeable, but the merge key is not sufficiently unique, which can cause data corruption when it is merged. Callers should instead use a full-replacement patch. See http://pr.k8s.io/79391 for an example.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeAddress" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "allocatable" = mkOption {
           description = "Allocatable represents the resources of a node that are available for scheduling. Defaults to Capacity.";
@@ -7194,7 +7213,7 @@ let
         "conditions" = mkOption {
           description = "Conditions is an array of current observed node conditions. More info: https://kubernetes.io/docs/concepts/nodes/node/#condition";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "config" = mkOption {
           description = "Status of the config assigned to the node via the dynamic Kubelet config feature.";
@@ -7560,7 +7579,7 @@ let
         "conditions" = mkOption {
           description = "conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PersistentVolumeClaimCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "phase" = mkOption {
           description = "phase represents the current phase of PersistentVolumeClaim.\n\n";
@@ -8189,7 +8208,7 @@ let
         "containers" = mkOption {
           description = "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.";
           type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name");
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "dnsConfig" = mkOption {
           description = "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.";
@@ -8206,12 +8225,12 @@ let
         "ephemeralContainers" = mkOption {
           description = "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "hostAliases" = mkOption {
           description = "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HostAlias" "ip"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "hostIPC" = mkOption {
           description = "Use the host's ipc namespace. Optional: Default to false.";
@@ -8236,12 +8255,12 @@ let
         "imagePullSecrets" = mkOption {
           description = "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "initContainers" = mkOption {
           description = "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "nodeName" = mkOption {
           description = "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.";
@@ -8322,12 +8341,12 @@ let
         "topologySpreadConstraints" = mkOption {
           description = "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.TopologySpreadConstraint" "topologyKey"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumes" = mkOption {
           description = "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Volume" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -8378,7 +8397,7 @@ let
         "conditions" = mkOption {
           description = "Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "containerStatuses" = mkOption {
           description = "The list has one entry per container in the manifest. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status";
@@ -8415,7 +8434,7 @@ let
         "podIPs" = mkOption {
           description = "podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list is empty if no IPs have been allocated yet.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodIP" "ip"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "qosClass" = mkOption {
           description = "The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md\n\n";
@@ -8943,7 +8962,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replication controller's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ReplicationControllerCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
           description = "The number of pods that have labels matching the labels of the pod template of the replication controller.";
@@ -9646,7 +9665,7 @@ let
         "secrets" = mkOption {
           description = "Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use. Pods are only limited to this list if this service account has a \"kubernetes.io/enforce-mountable-secrets\" annotation set to \"true\". This field should not be used to find auto-generated service account token secrets for use outside of pods. Instead, tokens can be requested directly using the TokenRequest API, or service account token secrets can be manually created. More info: https://kubernetes.io/docs/concepts/configuration/secret";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -9840,7 +9859,7 @@ let
         "ports" = mkOption {
           description = "The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ServicePort" "port"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "publishNotReadyAddresses" = mkOption {
           description = "publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered \"ready\" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.";
@@ -9894,7 +9913,7 @@ let
         "conditions" = mkOption {
           description = "Current service state";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "loadBalancer" = mkOption {
           description = "LoadBalancer contains the current status of the load-balancer, if one is present.";
@@ -12435,7 +12454,7 @@ let
         "conditions" = mkOption {
           description = "Conditions holds an array of metav1.Condition that describe the state of the NetworkPolicy. Current service state";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -12781,7 +12800,7 @@ let
         "conditions" = mkOption {
           description = "Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute\n              the number of allowed disruptions. Therefore no disruptions are\n              allowed and the status of the condition will be False.\n- InsufficientPods: The number of pods are either at or below the number\n                    required by the PodDisruptionBudget. No disruptions are\n                    allowed and the status of the condition will be False.\n- SufficientPods: There are more pods than required by the PodDisruptionBudget.\n                  The condition will be True, and the number of allowed\n                  disruptions are provided by the disruptionsAllowed property.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentHealthy" = mkOption {
           description = "current number of healthy pods";
@@ -13437,7 +13456,7 @@ let
         "drivers" = mkOption {
           description = "drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.";
           type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1.CSINodeDriver" "name");
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -14422,7 +14441,7 @@ let
         "x-kubernetes-validations" = mkOption {
           description = "x-kubernetes-validations describes a list of validation rules written in the CEL expression language. This field is an alpha-level. Using this field requires the feature gate `CustomResourceValidationExpressions` to be enabled.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule" "rule"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -15010,7 +15029,7 @@ let
         "ownerReferences" = mkOption {
           description = "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference" "uid"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "resourceVersion" = mkOption {
           description = "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency";
@@ -15446,7 +15465,7 @@ let
         "conditions" = mkOption {
           description = "Current service state of apiService.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 

--- a/modules/generated/v1.26.nix
+++ b/modules/generated/v1.26.nix
@@ -4,6 +4,21 @@
 with lib;
 
 let
+  hasAttrNotNull = attr: set: hasAttr attr set && !isNull set.${attr};
+
+  attrsToList = values:
+    if values != null
+    then
+      sort
+        (a: b:
+          if (hasAttrNotNull "_priority" a && hasAttrNotNull "_priority" b)
+          then a._priority < b._priority
+          else false
+        )
+        (mapAttrsToList (n: v: v) values)
+    else
+      values;
+
   getDefaults = resource: group: version: kind:
     catAttrs "default" (filter
       (default:
@@ -51,15 +66,16 @@ let
 
   mkOptionDefault = mkOverride 1001;
 
+  # todo: can we use mkOrder
   mergeValuesByKey = mergeKey: values:
-    listToAttrs (map
-      (value: nameValuePair
+    listToAttrs (imap0
+      (i: value: nameValuePair
         (
           if isAttrs value.${mergeKey}
           then toString value.${mergeKey}.content
           else (toString value.${mergeKey})
         )
-        value)
+        (value // { _priority = i; }))
       values);
 
   submoduleOf = ref: types.submodule ({ name, ... }: {
@@ -75,7 +91,10 @@ let
         else name;
     in
     {
-      options = definitions."${ref}".options;
+      options = definitions."${ref}".options // {
+        # position in original array
+        _priority = mkOption { type = types.nullOr types.int; default = null; };
+      };
       config = definitions."${ref}".config // {
         ${mergeKey} = mkOverride 1002 (convertName name);
       };
@@ -186,7 +205,7 @@ let
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.MutatingWebhook" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -365,7 +384,7 @@ let
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.ValidatingWebhook" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -1098,7 +1117,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a DaemonSet's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DaemonSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentNumberScheduled" = mkOption {
           description = "The number of nodes that are running at least 1 daemon pod and are supposed to run the daemon pod. More info: https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/";
@@ -1329,7 +1348,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a deployment's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DeploymentCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "observedGeneration" = mkOption {
           description = "The generation observed by the deployment controller.";
@@ -1522,7 +1541,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replica set's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.ReplicaSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
           description = "The number of pods that have labels matching the labels of the pod template of the replicaset.";
@@ -1820,7 +1839,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a statefulset's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.StatefulSetCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentReplicas" = mkOption {
           description = "currentReplicas is the number of Pods created by the StatefulSet controller from the StatefulSet version indicated by currentRevision.";
@@ -3048,7 +3067,7 @@ let
         "conditions" = mkOption {
           description = "conditions is the set of conditions required for this autoscaler to scale its target, and indicates whether or not those conditions are met.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentMetrics" = mkOption {
           description = "currentMetrics is the last read state of the metrics used by this autoscaler.";
@@ -3664,7 +3683,7 @@ let
         "conditions" = mkOption {
           description = "The latest available observations of an object's current state. When a Job fails, one of the conditions will have type \"Failed\" and status true. When a Job is suspended, one of the conditions will have type \"Suspended\" and status true; when the Job is resumed, the status of this condition will become false. When a Job is completed, one of the conditions will have type \"Complete\" and status true. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.batch.v1.JobCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "failed" = mkOption {
           description = "The number of pods which reached phase Failed.";
@@ -4591,7 +4610,7 @@ let
         "conditions" = mkOption {
           description = "List of component conditions observed";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ComponentCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "kind" = mkOption {
           description = "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds";
@@ -4855,7 +4874,7 @@ let
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "envFrom" = mkOption {
           description = "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.";
@@ -4884,7 +4903,7 @@ let
         "ports" = mkOption {
           description = "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "readinessProbe" = mkOption {
           description = "Periodic probe of container service readiness. Container will be removed from service endpoints if the probe fails. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#container-probes";
@@ -4925,12 +4944,12 @@ let
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "workingDir" = mkOption {
           description = "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.";
@@ -5504,7 +5523,7 @@ let
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "envFrom" = mkOption {
           description = "List of sources to populate environment variables in the container. The keys defined within a source must be a C_IDENTIFIER. All invalid keys will be reported as an event when the container is starting. When a key exists in multiple sources, the value associated with the last source will take precedence. Values defined by an Env with a duplicate key will take precedence. Cannot be updated.";
@@ -5533,7 +5552,7 @@ let
         "ports" = mkOption {
           description = "Ports are not allowed for ephemeral containers.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "readinessProbe" = mkOption {
           description = "Probes are not allowed for ephemeral containers.";
@@ -5578,12 +5597,12 @@ let
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "workingDir" = mkOption {
           description = "Container's working directory. If not specified, the container runtime's default will be used, which might be configured in the container image. Cannot be updated.";
@@ -6664,7 +6683,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a namespace's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NamespaceCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "phase" = mkOption {
           description = "Phase is the current lifecycle phase of the namespace. More info: https://kubernetes.io/docs/tasks/administer-cluster/namespaces/\n\n";
@@ -6985,7 +7004,7 @@ let
         "addresses" = mkOption {
           description = "List of addresses reachable to the node. Queried from cloud provider, if available. More info: https://kubernetes.io/docs/concepts/nodes/node/#addresses Note: This field is declared as mergeable, but the merge key is not sufficiently unique, which can cause data corruption when it is merged. Callers should instead use a full-replacement patch. See https://pr.k8s.io/79391 for an example.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeAddress" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "allocatable" = mkOption {
           description = "Allocatable represents the resources of a node that are available for scheduling. Defaults to Capacity.";
@@ -6998,7 +7017,7 @@ let
         "conditions" = mkOption {
           description = "Conditions is an array of current observed node conditions. More info: https://kubernetes.io/docs/concepts/nodes/node/#condition";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "config" = mkOption {
           description = "Status of the config assigned to the node via the dynamic Kubelet config feature.";
@@ -7364,7 +7383,7 @@ let
         "conditions" = mkOption {
           description = "conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PersistentVolumeClaimCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "phase" = mkOption {
           description = "phase represents the current phase of PersistentVolumeClaim.\n\n";
@@ -8025,7 +8044,7 @@ let
         "containers" = mkOption {
           description = "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.";
           type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name");
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "dnsConfig" = mkOption {
           description = "Specifies the DNS parameters of a pod. Parameters specified here will be merged to the generated DNS configuration based on DNSPolicy.";
@@ -8042,12 +8061,12 @@ let
         "ephemeralContainers" = mkOption {
           description = "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "hostAliases" = mkOption {
           description = "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HostAlias" "ip"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "hostIPC" = mkOption {
           description = "Use the host's ipc namespace. Optional: Default to false.";
@@ -8072,12 +8091,12 @@ let
         "imagePullSecrets" = mkOption {
           description = "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "initContainers" = mkOption {
           description = "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "nodeName" = mkOption {
           description = "NodeName is a request to schedule this pod onto a specific node. If it is non-empty, the scheduler simply schedules this pod onto that node, assuming that it fits resource requirements.";
@@ -8114,7 +8133,7 @@ let
         "resourceClaims" = mkOption {
           description = "ResourceClaims defines which ResourceClaims must be allocated and reserved before the Pod is allowed to start. The resources will be made available to those containers which consume them by name.\n\nThis is an alpha field and requires enabling the DynamicResourceAllocation feature gate.\n\nThis field is immutable.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodResourceClaim" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "restartPolicy" = mkOption {
           description = "Restart policy for all containers within the pod. One of Always, OnFailure, Never. Default to Always. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy\n\n";
@@ -8131,7 +8150,7 @@ let
         "schedulingGates" = mkOption {
           description = "SchedulingGates is an opaque list of values that if specified will block scheduling the pod. More info:  https://git.k8s.io/enhancements/keps/sig-scheduling/3521-pod-scheduling-readiness.\n\nThis is an alpha-level feature enabled by PodSchedulingReadiness feature gate.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodSchedulingGate" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "securityContext" = mkOption {
           description = "SecurityContext holds pod-level security attributes and common container settings. Optional: Defaults to empty.  See type description for default values of each field.";
@@ -8168,12 +8187,12 @@ let
         "topologySpreadConstraints" = mkOption {
           description = "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.TopologySpreadConstraint" "topologyKey"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "volumes" = mkOption {
           description = "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Volume" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -8226,7 +8245,7 @@ let
         "conditions" = mkOption {
           description = "Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "containerStatuses" = mkOption {
           description = "The list has one entry per container in the manifest. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status";
@@ -8263,7 +8282,7 @@ let
         "podIPs" = mkOption {
           description = "podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list is empty if no IPs have been allocated yet.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodIP" "ip"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "qosClass" = mkOption {
           description = "The Quality of Service (QOS) classification assigned to the pod based on resource requirements See PodQOSClass type for available QOS classes More info: https://git.k8s.io/community/contributors/design-proposals/node/resource-qos.md\n\n";
@@ -8791,7 +8810,7 @@ let
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replication controller's current state.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ReplicationControllerCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
           description = "The number of pods that have labels matching the labels of the pod template of the replication controller.";
@@ -9512,7 +9531,7 @@ let
         "secrets" = mkOption {
           description = "Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use. Pods are only limited to this list if this service account has a \"kubernetes.io/enforce-mountable-secrets\" annotation set to \"true\". This field should not be used to find auto-generated service account token secrets for use outside of pods. Instead, tokens can be requested directly using the TokenRequest API, or service account token secrets can be manually created. More info: https://kubernetes.io/docs/concepts/configuration/secret";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -9706,7 +9725,7 @@ let
         "ports" = mkOption {
           description = "The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ServicePort" "port"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "publishNotReadyAddresses" = mkOption {
           description = "publishNotReadyAddresses indicates that any agent which deals with endpoints for this Service should disregard any indications of ready/not-ready. The primary use case for setting this field is for a StatefulSet's Headless Service to propagate SRV DNS records for its Pods for the purpose of peer discovery. The Kubernetes controllers that generate Endpoints and EndpointSlice resources for Services interpret this to mean that all endpoints are considered \"ready\" even if the Pods themselves are not. Agents which consume only Kubernetes generated endpoints through the Endpoints or EndpointSlice resources can safely assume this behavior.";
@@ -9760,7 +9779,7 @@ let
         "conditions" = mkOption {
           description = "Current service state";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "loadBalancer" = mkOption {
           description = "LoadBalancer contains the current status of the load-balancer, if one is present.";
@@ -11431,7 +11450,7 @@ let
         "conditions" = mkOption {
           description = "`conditions` is a list of the current states of FlowSchema.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.flowcontrol.v1beta3.FlowSchemaCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -11681,7 +11700,7 @@ let
         "conditions" = mkOption {
           description = "`conditions` is the current state of \"request-priority\".";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.flowcontrol.v1beta3.PriorityLevelConfigurationCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -12414,7 +12433,7 @@ let
         "conditions" = mkOption {
           description = "Conditions holds an array of metav1.Condition that describe the state of the NetworkPolicy. Current service state";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -12765,7 +12784,7 @@ let
         "conditions" = mkOption {
           description = "Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute\n              the number of allowed disruptions. Therefore no disruptions are\n              allowed and the status of the condition will be False.\n- InsufficientPods: The number of pods are either at or below the number\n                    required by the PodDisruptionBudget. No disruptions are\n                    allowed and the status of the condition will be False.\n- SufficientPods: There are more pods than required by the PodDisruptionBudget.\n                  The condition will be True, and the number of allowed\n                  disruptions are provided by the disruptionsAllowed property.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "currentHealthy" = mkOption {
           description = "current number of healthy pods";
@@ -13904,7 +13923,7 @@ let
         "drivers" = mkOption {
           description = "drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.";
           type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1.CSINodeDriver" "name");
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -14889,7 +14908,7 @@ let
         "x-kubernetes-validations" = mkOption {
           description = "x-kubernetes-validations describes a list of validation rules written in the CEL expression language. This field is an alpha-level. Using this field requires the feature gate `CustomResourceValidationExpressions` to be enabled.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule" "rule"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 
@@ -15477,7 +15496,7 @@ let
         "ownerReferences" = mkOption {
           description = "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference" "uid"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
         "resourceVersion" = mkOption {
           description = "An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.\n\nPopulated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency";
@@ -15913,7 +15932,7 @@ let
         "conditions" = mkOption {
           description = "Current service state of apiService.";
           type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition" "type"));
-          apply = values: if values != null then mapAttrsToList (n: v: v) values else values;
+          apply = attrsToList;
         };
       };
 


### PR DESCRIPTION
This change temporarily stores the position of an element in its array so that the original order can be restored after the config is merged via attributes in `mergeValuesByKey`.

closes hall/kubenix#19