### PR TITLE
Use name as fallback merge-key

### DIFF
--- a/modules/generated/v1.19.nix
+++ b/modules/generated/v1.19.nix
@@ -66,14 +66,24 @@ let
 
   mkOptionDefault = mkOverride 1001;
 
-  # todo: can we use mkOrder
-  mergeValuesByKey = mergeKey: values:
+  mergeValuesByKey = attrMergeKey: listMergeKeys: values:
     listToAttrs (imap0
       (i: value: nameValuePair
         (
-          if isAttrs value.${mergeKey}
-          then toString value.${mergeKey}.content
-          else (toString value.${mergeKey})
+          if hasAttr attrMergeKey value
+          then
+            if isAttrs value.${attrMergeKey}
+            then toString value.${attrMergeKey}.content
+            else (toString value.${attrMergeKey})
+          else
+          # generate merge key for list elements if it's not present
+            "__kubenix_list_merge_key_" + (concatStringsSep "" (map
+              (key:
+                if isAttrs value.${key}
+                then toString value.${key}.content
+                else (toString value.${key})
+              )
+              listMergeKeys))
         )
         (value // { _priority = i; }))
       values);
@@ -96,7 +106,12 @@ let
         _priority = mkOption { type = types.nullOr types.int; default = null; };
       };
       config = definitions."${ref}".config // {
-        ${mergeKey} = mkOverride 1002 (convertName name);
+        ${mergeKey} = mkOverride 1002 (
+          # use name as mergeKey only if it is not coming from mergeValuesByKey
+          if (!hasPrefix "__kubenix_list_merge_key_" name)
+          then convertName name
+          else null
+        );
       };
     });
 
@@ -119,10 +134,10 @@ let
       ];
     });
 
-  coerceAttrsOfSubmodulesToListByKey = ref: mergeKey: (types.coercedTo
+  coerceAttrsOfSubmodulesToListByKey = ref: attrMergeKey: listMergeKeys: (types.coercedTo
     (types.listOf (submoduleOf ref))
-    (mergeValuesByKey mergeKey)
-    (types.attrsOf (submoduleWithMergeOf ref mergeKey))
+    (mergeValuesByKey attrMergeKey listMergeKeys)
+    (types.attrsOf (submoduleWithMergeOf ref attrMergeKey))
   );
 
   definitions = {
@@ -204,7 +219,7 @@ let
         };
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.MutatingWebhook" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.MutatingWebhook" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -383,7 +398,7 @@ let
         };
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.ValidatingWebhook" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.ValidatingWebhook" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -531,7 +546,7 @@ let
         };
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1beta1.MutatingWebhook" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1beta1.MutatingWebhook" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -712,7 +727,7 @@ let
         };
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1beta1.ValidatingWebhook" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1beta1.ValidatingWebhook" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -982,7 +997,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a DaemonSet's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DaemonSetCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DaemonSetCondition" "type" [ ]));
           apply = attrsToList;
         };
         "currentNumberScheduled" = mkOption {
@@ -1213,7 +1228,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a deployment's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DeploymentCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DeploymentCondition" "type" [ ]));
           apply = attrsToList;
         };
         "observedGeneration" = mkOption {
@@ -1406,7 +1421,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replica set's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.ReplicaSetCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.ReplicaSetCondition" "type" [ ]));
           apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
@@ -1640,7 +1655,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a statefulset's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.StatefulSetCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.StatefulSetCondition" "type" [ ]));
           apply = attrsToList;
         };
         "currentReplicas" = mkOption {
@@ -4188,7 +4203,7 @@ let
         };
         "conditions" = mkOption {
           description = "The latest available observations of an object's current state. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.batch.v1.JobCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.batch.v1.JobCondition" "type" [ ]));
           apply = attrsToList;
         };
         "failed" = mkOption {
@@ -4328,7 +4343,8 @@ let
       options = {
         "active" = mkOption {
           description = "A list of pointers to currently running jobs.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ObjectReference")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name" [ ]));
+          apply = attrsToList;
         };
         "lastScheduleTime" = mkOption {
           description = "Information when was the last time the job was successfully scheduled.";
@@ -4475,7 +4491,8 @@ let
       options = {
         "active" = mkOption {
           description = "A list of pointers to currently running jobs.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ObjectReference")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name" [ ]));
+          apply = attrsToList;
         };
         "lastScheduleTime" = mkOption {
           description = "Information when was the last time the job was successfully scheduled.";
@@ -5513,7 +5530,7 @@ let
         };
         "conditions" = mkOption {
           description = "List of component conditions observed";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ComponentCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ComponentCondition" "type" [ ]));
           apply = attrsToList;
         };
         "kind" = mkOption {
@@ -5777,7 +5794,7 @@ let
         };
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name" [ ]));
           apply = attrsToList;
         };
         "envFrom" = mkOption {
@@ -5806,7 +5823,7 @@ let
         };
         "ports" = mkOption {
           description = "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "name" [ "containerPort" "protocol" ]));
           apply = attrsToList;
         };
         "readinessProbe" = mkOption {
@@ -5847,12 +5864,12 @@ let
         };
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath" [ ]));
           apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath" [ ]));
           apply = attrsToList;
         };
         "workingDir" = mkOption {
@@ -6262,7 +6279,8 @@ let
         };
         "ports" = mkOption {
           description = "Port numbers available on the related IP addresses.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.EndpointPort")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EndpointPort" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -6425,7 +6443,7 @@ let
         };
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name" [ ]));
           apply = attrsToList;
         };
         "envFrom" = mkOption {
@@ -6454,7 +6472,8 @@ let
         };
         "ports" = mkOption {
           description = "Ports are not allowed for ephemeral containers.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ContainerPort")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "name" [ ]));
+          apply = attrsToList;
         };
         "readinessProbe" = mkOption {
           description = "Probes are not allowed for ephemeral containers.";
@@ -6498,12 +6517,12 @@ let
         };
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath" [ ]));
           apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath" [ ]));
           apply = attrsToList;
         };
         "workingDir" = mkOption {
@@ -6972,7 +6991,8 @@ let
         };
         "httpHeaders" = mkOption {
           description = "Custom headers to set in the request. HTTP allows repeated headers.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.HTTPHeader")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HTTPHeader" "name" [ ]));
+          apply = attrsToList;
         };
         "path" = mkOption {
           description = "Path to access on the HTTP server.";
@@ -7565,7 +7585,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Represents the latest available observations of a namespace's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NamespaceCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NamespaceCondition" "type" [ ]));
           apply = attrsToList;
         };
         "phase" = mkOption {
@@ -7886,7 +7906,7 @@ let
       options = {
         "addresses" = mkOption {
           description = "List of addresses reachable to the node. Queried from cloud provider, if available. More info: https://kubernetes.io/docs/concepts/nodes/node/#addresses Note: This field is declared as mergeable, but the merge key is not sufficiently unique, which can cause data corruption when it is merged. Callers should instead use a full-replacement patch. See http://pr.k8s.io/79391 for an example.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeAddress" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeAddress" "type" [ ]));
           apply = attrsToList;
         };
         "allocatable" = mkOption {
@@ -7899,7 +7919,7 @@ let
         };
         "conditions" = mkOption {
           description = "Conditions is an array of current observed node conditions. More info: https://kubernetes.io/docs/concepts/nodes/node/#condition";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeCondition" "type" [ ]));
           apply = attrsToList;
         };
         "config" = mkOption {
@@ -7924,7 +7944,8 @@ let
         };
         "volumesAttached" = mkOption {
           description = "List of volumes that are attached to the node.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.AttachedVolume")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.AttachedVolume" "name" [ ]));
+          apply = attrsToList;
         };
         "volumesInUse" = mkOption {
           description = "List of attachable volumes in use (mounted) by the node.";
@@ -8256,7 +8277,7 @@ let
         };
         "conditions" = mkOption {
           description = "Current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PersistentVolumeClaimCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PersistentVolumeClaimCondition" "type" [ ]));
           apply = attrsToList;
         };
         "phase" = mkOption {
@@ -8691,7 +8712,8 @@ let
         };
         "options" = mkOption {
           description = "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.PodDNSConfigOption")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodDNSConfigOption" "name" [ ]));
+          apply = attrsToList;
         };
         "searches" = mkOption {
           description = "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.";
@@ -8821,7 +8843,8 @@ let
         };
         "sysctls" = mkOption {
           description = "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.Sysctl")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Sysctl" "name" [ ]));
+          apply = attrsToList;
         };
         "windowsOptions" = mkOption {
           description = "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.";
@@ -8861,7 +8884,7 @@ let
         };
         "containers" = mkOption {
           description = "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.";
-          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name");
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name" [ ]);
           apply = attrsToList;
         };
         "dnsConfig" = mkOption {
@@ -8878,12 +8901,12 @@ let
         };
         "ephemeralContainers" = mkOption {
           description = "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name" [ ]));
           apply = attrsToList;
         };
         "hostAliases" = mkOption {
           description = "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HostAlias" "ip"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HostAlias" "ip" [ ]));
           apply = attrsToList;
         };
         "hostIPC" = mkOption {
@@ -8904,12 +8927,12 @@ let
         };
         "imagePullSecrets" = mkOption {
           description = "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name" [ ]));
           apply = attrsToList;
         };
         "initContainers" = mkOption {
           description = "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name" [ ]));
           apply = attrsToList;
         };
         "nodeName" = mkOption {
@@ -8986,12 +9009,11 @@ let
         };
         "topologySpreadConstraints" = mkOption {
           description = "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.TopologySpreadConstraint" "topologyKey"));
-          apply = attrsToList;
+          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.TopologySpreadConstraint")));
         };
         "volumes" = mkOption {
           description = "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Volume" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Volume" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -9040,16 +9062,18 @@ let
       options = {
         "conditions" = mkOption {
           description = "Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodCondition" "type" [ ]));
           apply = attrsToList;
         };
         "containerStatuses" = mkOption {
           description = "The list has one entry per container in the manifest. Each entry is currently the output of `docker inspect`. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ContainerStatus")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerStatus" "name" [ ]));
+          apply = attrsToList;
         };
         "ephemeralContainerStatuses" = mkOption {
           description = "Status for any ephemeral containers that have run in this pod. This field is alpha-level and is only populated by servers that enable the EphemeralContainers feature.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ContainerStatus")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerStatus" "name" [ ]));
+          apply = attrsToList;
         };
         "hostIP" = mkOption {
           description = "IP address of the host to which the pod is assigned. Empty if not yet scheduled.";
@@ -9057,7 +9081,8 @@ let
         };
         "initContainerStatuses" = mkOption {
           description = "The list has one entry per init container in the manifest. The most recent successful init container will have ready = true, the most recently started container will have startTime set. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ContainerStatus")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerStatus" "name" [ ]));
+          apply = attrsToList;
         };
         "message" = mkOption {
           description = "A human readable message indicating details about why the pod is in this condition.";
@@ -9077,7 +9102,7 @@ let
         };
         "podIPs" = mkOption {
           description = "podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list is empty if no IPs have been allocated yet.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodIP" "ip"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodIP" "ip" [ ]));
           apply = attrsToList;
         };
         "qosClass" = mkOption {
@@ -9571,7 +9596,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replication controller's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ReplicationControllerCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ReplicationControllerCondition" "type" [ ]));
           apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
@@ -10262,7 +10287,8 @@ let
         };
         "imagePullSecrets" = mkOption {
           description = "ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.LocalObjectReference")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name" [ ]));
+          apply = attrsToList;
         };
         "kind" = mkOption {
           description = "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds";
@@ -10274,7 +10300,7 @@ let
         };
         "secrets" = mkOption {
           description = "Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: https://kubernetes.io/docs/concepts/configuration/secret";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -10448,7 +10474,7 @@ let
         };
         "ports" = mkOption {
           description = "The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ServicePort" "port"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ServicePort" "name" [ "port" "protocol" ]));
           apply = attrsToList;
         };
         "publishNotReadyAddresses" = mkOption {
@@ -11212,7 +11238,8 @@ let
         };
         "ports" = mkOption {
           description = "ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates \"all ports\". Each slice may include a maximum of 100 ports.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.discovery.v1beta1.EndpointPort")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.discovery.v1beta1.EndpointPort" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -13605,7 +13632,8 @@ let
         };
         "allowedCSIDrivers" = mkOption {
           description = "AllowedCSIDrivers is an allowlist of inline CSI drivers that must be explicitly set to be embedded within a pod spec. An empty value indicates that any CSI driver can be used for inline ephemeral volumes. This is a beta field, and is only honored if the API server enables the CSIInlineVolume feature gate.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.policy.v1beta1.AllowedCSIDriver")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.policy.v1beta1.AllowedCSIDriver" "name" [ ]));
+          apply = attrsToList;
         };
         "allowedCapabilities" = mkOption {
           description = "allowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field may be added at the pod author's discretion. You must not list a capability in both allowedCapabilities and requiredDropCapabilities.";
@@ -13889,7 +13917,8 @@ let
         };
         "subjects" = mkOption {
           description = "Subjects holds references to the objects the role applies to.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.rbac.v1.Subject")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.rbac.v1.Subject" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -14045,7 +14074,8 @@ let
         };
         "subjects" = mkOption {
           description = "Subjects holds references to the objects the role applies to.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.rbac.v1.Subject")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.rbac.v1.Subject" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -14236,7 +14266,8 @@ let
         };
         "subjects" = mkOption {
           description = "Subjects holds references to the objects the role applies to.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.rbac.v1alpha1.Subject")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.rbac.v1alpha1.Subject" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -14392,7 +14423,8 @@ let
         };
         "subjects" = mkOption {
           description = "Subjects holds references to the objects the role applies to.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.rbac.v1alpha1.Subject")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.rbac.v1alpha1.Subject" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -14583,7 +14615,8 @@ let
         };
         "subjects" = mkOption {
           description = "Subjects holds references to the objects the role applies to.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.rbac.v1beta1.Subject")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.rbac.v1beta1.Subject" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -14739,7 +14772,8 @@ let
         };
         "subjects" = mkOption {
           description = "Subjects holds references to the objects the role applies to.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.rbac.v1beta1.Subject")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.rbac.v1beta1.Subject" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -15142,7 +15176,8 @@ let
       options = {
         "env" = mkOption {
           description = "Env defines the collection of EnvVar to inject into containers.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.EnvVar")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name" [ ]));
+          apply = attrsToList;
         };
         "envFrom" = mkOption {
           description = "EnvFrom defines the collection of EnvFromSource to inject into containers.";
@@ -15154,11 +15189,13 @@ let
         };
         "volumeMounts" = mkOption {
           description = "VolumeMounts defines the collection of VolumeMount to inject into containers.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.VolumeMount")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "name" [ ]));
+          apply = attrsToList;
         };
         "volumes" = mkOption {
           description = "Volumes defines the collection of Volume to inject into the pod.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.Volume")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Volume" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -15356,7 +15393,7 @@ let
       options = {
         "drivers" = mkOption {
           description = "drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.";
-          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1.CSINodeDriver" "name");
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1.CSINodeDriver" "name" [ ]);
           apply = attrsToList;
         };
       };
@@ -15958,7 +15995,7 @@ let
       options = {
         "drivers" = mkOption {
           description = "drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.";
-          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1beta1.CSINodeDriver" "name");
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1beta1.CSINodeDriver" "name" [ ]);
           apply = attrsToList;
         };
       };
@@ -16438,7 +16475,8 @@ let
         };
         "versions" = mkOption {
           description = "versions is the list of all API versions of the defined custom resource. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is \"kube-like\", it will sort above non \"kube-like\" version strings, which are ordered lexicographically. \"Kube-like\" versions start with a \"v\", then are followed by a number (the major version), then optionally the string \"alpha\" or \"beta\" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.";
-          type = (types.listOf (submoduleOf "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion"));
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion" "name" [ ]);
+          apply = attrsToList;
         };
       };
 
@@ -16479,7 +16517,8 @@ let
       options = {
         "additionalPrinterColumns" = mkOption {
           description = "additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. If no columns are specified, a single column displaying the age of the custom resource is used.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition" "name" [ ]));
+          apply = attrsToList;
         };
         "deprecated" = mkOption {
           description = "deprecated indicates this version of the custom resource API is deprecated. When set to true, API requests to this version receive a warning header in the server response. Defaults to false.";
@@ -17101,7 +17140,8 @@ let
       options = {
         "additionalPrinterColumns" = mkOption {
           description = "additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. If present, this field configures columns for all versions. Top-level and per-version columns are mutually exclusive. If no top-level or per-version columns are specified, a single column displaying the age of the custom resource is used.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceColumnDefinition")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceColumnDefinition" "name" [ ]));
+          apply = attrsToList;
         };
         "conversion" = mkOption {
           description = "conversion defines conversion settings for the CRD.";
@@ -17137,7 +17177,8 @@ let
         };
         "versions" = mkOption {
           description = "versions is the list of all API versions of the defined custom resource. Optional if `version` is specified. The name of the first item in the `versions` list must match the `version` field if `version` and `versions` are both specified. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is \"kube-like\", it will sort above non \"kube-like\" version strings, which are ordered lexicographically. \"Kube-like\" versions start with a \"v\", then are followed by a number (the major version), then optionally the string \"alpha\" or \"beta\" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionVersion")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionVersion" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -17183,7 +17224,8 @@ let
       options = {
         "additionalPrinterColumns" = mkOption {
           description = "additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. Top-level and per-version columns are mutually exclusive. Per-version columns must not all be set to identical values (top-level columns should be used instead). If no top-level or per-version columns are specified, a single column displaying the age of the custom resource is used.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceColumnDefinition")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceColumnDefinition" "name" [ ]));
+          apply = attrsToList;
         };
         "deprecated" = mkOption {
           description = "deprecated indicates this version of the custom resource API is deprecated. When set to true, API requests to this version receive a warning header in the server response. Defaults to false.";
@@ -17634,7 +17676,8 @@ let
         };
         "groups" = mkOption {
           description = "groups is a list of APIGroup.";
-          type = (types.listOf (submoduleOf "io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"));
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup" "name" [ ]);
+          apply = attrsToList;
         };
         "kind" = mkOption {
           description = "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds";
@@ -17721,7 +17764,8 @@ let
         };
         "resources" = mkOption {
           description = "resources contains the name of the resources and if they are namespaced.";
-          type = (types.listOf (submoduleOf "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"));
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource" "name" [ ]);
+          apply = attrsToList;
         };
       };
 
@@ -17990,7 +18034,7 @@ let
         };
         "ownerReferences" = mkOption {
           description = "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference" "uid"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference" "uid" [ ]));
           apply = attrsToList;
         };
         "resourceVersion" = mkOption {
@@ -18427,7 +18471,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Current service state of apiService.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition" "type" [ ]));
           apply = attrsToList;
         };
       };
@@ -18608,7 +18652,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Current service state of apiService.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceCondition" "type" [ ]));
           apply = attrsToList;
         };
       };

--- a/modules/generated/v1.21.nix
+++ b/modules/generated/v1.21.nix
@@ -66,14 +66,24 @@ let
 
   mkOptionDefault = mkOverride 1001;
 
-  # todo: can we use mkOrder
-  mergeValuesByKey = mergeKey: values:
+  mergeValuesByKey = attrMergeKey: listMergeKeys: values:
     listToAttrs (imap0
       (i: value: nameValuePair
         (
-          if isAttrs value.${mergeKey}
-          then toString value.${mergeKey}.content
-          else (toString value.${mergeKey})
+          if hasAttr attrMergeKey value
+          then
+            if isAttrs value.${attrMergeKey}
+            then toString value.${attrMergeKey}.content
+            else (toString value.${attrMergeKey})
+          else
+          # generate merge key for list elements if it's not present
+            "__kubenix_list_merge_key_" + (concatStringsSep "" (map
+              (key:
+                if isAttrs value.${key}
+                then toString value.${key}.content
+                else (toString value.${key})
+              )
+              listMergeKeys))
         )
         (value // { _priority = i; }))
       values);
@@ -96,7 +106,12 @@ let
         _priority = mkOption { type = types.nullOr types.int; default = null; };
       };
       config = definitions."${ref}".config // {
-        ${mergeKey} = mkOverride 1002 (convertName name);
+        ${mergeKey} = mkOverride 1002 (
+          # use name as mergeKey only if it is not coming from mergeValuesByKey
+          if (!hasPrefix "__kubenix_list_merge_key_" name)
+          then convertName name
+          else null
+        );
       };
     });
 
@@ -119,10 +134,10 @@ let
       ];
     });
 
-  coerceAttrsOfSubmodulesToListByKey = ref: mergeKey: (types.coercedTo
+  coerceAttrsOfSubmodulesToListByKey = ref: attrMergeKey: listMergeKeys: (types.coercedTo
     (types.listOf (submoduleOf ref))
-    (mergeValuesByKey mergeKey)
-    (types.attrsOf (submoduleWithMergeOf ref mergeKey))
+    (mergeValuesByKey attrMergeKey listMergeKeys)
+    (types.attrsOf (submoduleWithMergeOf ref attrMergeKey))
   );
 
   definitions = {
@@ -204,7 +219,7 @@ let
         };
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.MutatingWebhook" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.MutatingWebhook" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -383,7 +398,7 @@ let
         };
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.ValidatingWebhook" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.ValidatingWebhook" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -531,7 +546,7 @@ let
         };
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1beta1.MutatingWebhook" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1beta1.MutatingWebhook" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -712,7 +727,7 @@ let
         };
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1beta1.ValidatingWebhook" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1beta1.ValidatingWebhook" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -1132,7 +1147,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a DaemonSet's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DaemonSetCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DaemonSetCondition" "type" [ ]));
           apply = attrsToList;
         };
         "currentNumberScheduled" = mkOption {
@@ -1363,7 +1378,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a deployment's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DeploymentCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DeploymentCondition" "type" [ ]));
           apply = attrsToList;
         };
         "observedGeneration" = mkOption {
@@ -1556,7 +1571,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replica set's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.ReplicaSetCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.ReplicaSetCondition" "type" [ ]));
           apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
@@ -1795,7 +1810,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a statefulset's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.StatefulSetCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.StatefulSetCondition" "type" [ ]));
           apply = attrsToList;
         };
         "currentReplicas" = mkOption {
@@ -4408,7 +4423,8 @@ let
       options = {
         "active" = mkOption {
           description = "A list of pointers to currently running jobs.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ObjectReference")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name" [ ]));
+          apply = attrsToList;
         };
         "lastScheduleTime" = mkOption {
           description = "Information when was the last time the job was successfully scheduled.";
@@ -4606,7 +4622,7 @@ let
         };
         "conditions" = mkOption {
           description = "The latest available observations of an object's current state. When a Job fails, one of the conditions will have type \"Failed\" and status true. When a Job is suspended, one of the conditions will have type \"Suspended\" and status true; when the Job is resumed, the status of this condition will become false. When a Job is completed, one of the conditions will have type \"Complete\" and status true. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.batch.v1.JobCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.batch.v1.JobCondition" "type" [ ]));
           apply = attrsToList;
         };
         "failed" = mkOption {
@@ -4767,7 +4783,8 @@ let
       options = {
         "active" = mkOption {
           description = "A list of pointers to currently running jobs.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ObjectReference")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name" [ ]));
+          apply = attrsToList;
         };
         "lastScheduleTime" = mkOption {
           description = "Information when was the last time the job was successfully scheduled.";
@@ -5810,7 +5827,7 @@ let
         };
         "conditions" = mkOption {
           description = "List of component conditions observed";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ComponentCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ComponentCondition" "type" [ ]));
           apply = attrsToList;
         };
         "kind" = mkOption {
@@ -6074,7 +6091,7 @@ let
         };
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name" [ ]));
           apply = attrsToList;
         };
         "envFrom" = mkOption {
@@ -6103,7 +6120,7 @@ let
         };
         "ports" = mkOption {
           description = "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "name" [ "containerPort" "protocol" ]));
           apply = attrsToList;
         };
         "readinessProbe" = mkOption {
@@ -6144,12 +6161,12 @@ let
         };
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath" [ ]));
           apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath" [ ]));
           apply = attrsToList;
         };
         "workingDir" = mkOption {
@@ -6559,7 +6576,8 @@ let
         };
         "ports" = mkOption {
           description = "Port numbers available on the related IP addresses.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.EndpointPort")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EndpointPort" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -6722,7 +6740,7 @@ let
         };
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name" [ ]));
           apply = attrsToList;
         };
         "envFrom" = mkOption {
@@ -6751,7 +6769,8 @@ let
         };
         "ports" = mkOption {
           description = "Ports are not allowed for ephemeral containers.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ContainerPort")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "name" [ ]));
+          apply = attrsToList;
         };
         "readinessProbe" = mkOption {
           description = "Probes are not allowed for ephemeral containers.";
@@ -6795,12 +6814,12 @@ let
         };
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath" [ ]));
           apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath" [ ]));
           apply = attrsToList;
         };
         "workingDir" = mkOption {
@@ -6845,7 +6864,7 @@ let
         };
         "ephemeralContainers" = mkOption {
           description = "A list of ephemeral containers associated with this pod. New ephemeral containers may be appended to this list, but existing ephemeral containers may not be removed or modified.";
-          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name");
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name" [ ]);
           apply = attrsToList;
         };
         "kind" = mkOption {
@@ -7294,7 +7313,8 @@ let
         };
         "httpHeaders" = mkOption {
           description = "Custom headers to set in the request. HTTP allows repeated headers.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.HTTPHeader")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HTTPHeader" "name" [ ]));
+          apply = attrsToList;
         };
         "path" = mkOption {
           description = "Path to access on the HTTP server.";
@@ -7892,7 +7912,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Represents the latest available observations of a namespace's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NamespaceCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NamespaceCondition" "type" [ ]));
           apply = attrsToList;
         };
         "phase" = mkOption {
@@ -8213,7 +8233,7 @@ let
       options = {
         "addresses" = mkOption {
           description = "List of addresses reachable to the node. Queried from cloud provider, if available. More info: https://kubernetes.io/docs/concepts/nodes/node/#addresses Note: This field is declared as mergeable, but the merge key is not sufficiently unique, which can cause data corruption when it is merged. Callers should instead use a full-replacement patch. See http://pr.k8s.io/79391 for an example.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeAddress" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeAddress" "type" [ ]));
           apply = attrsToList;
         };
         "allocatable" = mkOption {
@@ -8226,7 +8246,7 @@ let
         };
         "conditions" = mkOption {
           description = "Conditions is an array of current observed node conditions. More info: https://kubernetes.io/docs/concepts/nodes/node/#condition";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeCondition" "type" [ ]));
           apply = attrsToList;
         };
         "config" = mkOption {
@@ -8251,7 +8271,8 @@ let
         };
         "volumesAttached" = mkOption {
           description = "List of volumes that are attached to the node.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.AttachedVolume")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.AttachedVolume" "name" [ ]));
+          apply = attrsToList;
         };
         "volumesInUse" = mkOption {
           description = "List of attachable volumes in use (mounted) by the node.";
@@ -8583,7 +8604,7 @@ let
         };
         "conditions" = mkOption {
           description = "Current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PersistentVolumeClaimCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PersistentVolumeClaimCondition" "type" [ ]));
           apply = attrsToList;
         };
         "phase" = mkOption {
@@ -9023,7 +9044,8 @@ let
         };
         "options" = mkOption {
           description = "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.PodDNSConfigOption")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodDNSConfigOption" "name" [ ]));
+          apply = attrsToList;
         };
         "searches" = mkOption {
           description = "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.";
@@ -9153,7 +9175,8 @@ let
         };
         "sysctls" = mkOption {
           description = "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.Sysctl")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Sysctl" "name" [ ]));
+          apply = attrsToList;
         };
         "windowsOptions" = mkOption {
           description = "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence.";
@@ -9193,7 +9216,7 @@ let
         };
         "containers" = mkOption {
           description = "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.";
-          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name");
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name" [ ]);
           apply = attrsToList;
         };
         "dnsConfig" = mkOption {
@@ -9210,12 +9233,12 @@ let
         };
         "ephemeralContainers" = mkOption {
           description = "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is alpha-level and is only honored by servers that enable the EphemeralContainers feature.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name" [ ]));
           apply = attrsToList;
         };
         "hostAliases" = mkOption {
           description = "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HostAlias" "ip"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HostAlias" "ip" [ ]));
           apply = attrsToList;
         };
         "hostIPC" = mkOption {
@@ -9236,12 +9259,12 @@ let
         };
         "imagePullSecrets" = mkOption {
           description = "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name" [ ]));
           apply = attrsToList;
         };
         "initContainers" = mkOption {
           description = "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name" [ ]));
           apply = attrsToList;
         };
         "nodeName" = mkOption {
@@ -9318,12 +9341,11 @@ let
         };
         "topologySpreadConstraints" = mkOption {
           description = "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.TopologySpreadConstraint" "topologyKey"));
-          apply = attrsToList;
+          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.TopologySpreadConstraint")));
         };
         "volumes" = mkOption {
           description = "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Volume" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Volume" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -9372,16 +9394,18 @@ let
       options = {
         "conditions" = mkOption {
           description = "Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodCondition" "type" [ ]));
           apply = attrsToList;
         };
         "containerStatuses" = mkOption {
           description = "The list has one entry per container in the manifest. Each entry is currently the output of `docker inspect`. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ContainerStatus")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerStatus" "name" [ ]));
+          apply = attrsToList;
         };
         "ephemeralContainerStatuses" = mkOption {
           description = "Status for any ephemeral containers that have run in this pod. This field is alpha-level and is only populated by servers that enable the EphemeralContainers feature.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ContainerStatus")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerStatus" "name" [ ]));
+          apply = attrsToList;
         };
         "hostIP" = mkOption {
           description = "IP address of the host to which the pod is assigned. Empty if not yet scheduled.";
@@ -9389,7 +9413,8 @@ let
         };
         "initContainerStatuses" = mkOption {
           description = "The list has one entry per init container in the manifest. The most recent successful init container will have ready = true, the most recently started container will have startTime set. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ContainerStatus")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerStatus" "name" [ ]));
+          apply = attrsToList;
         };
         "message" = mkOption {
           description = "A human readable message indicating details about why the pod is in this condition.";
@@ -9409,7 +9434,7 @@ let
         };
         "podIPs" = mkOption {
           description = "podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list is empty if no IPs have been allocated yet.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodIP" "ip"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodIP" "ip" [ ]));
           apply = attrsToList;
         };
         "qosClass" = mkOption {
@@ -9932,7 +9957,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replication controller's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ReplicationControllerCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ReplicationControllerCondition" "type" [ ]));
           apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
@@ -10623,7 +10648,8 @@ let
         };
         "imagePullSecrets" = mkOption {
           description = "ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.LocalObjectReference")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name" [ ]));
+          apply = attrsToList;
         };
         "kind" = mkOption {
           description = "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds";
@@ -10635,7 +10661,7 @@ let
         };
         "secrets" = mkOption {
           description = "Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: https://kubernetes.io/docs/concepts/configuration/secret";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -10829,7 +10855,7 @@ let
         };
         "ports" = mkOption {
           description = "The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ServicePort" "port"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ServicePort" "name" [ "port" "protocol" ]));
           apply = attrsToList;
         };
         "publishNotReadyAddresses" = mkOption {
@@ -10888,7 +10914,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Current service state";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type" [ ]));
           apply = attrsToList;
         };
         "loadBalancer" = mkOption {
@@ -11579,7 +11605,8 @@ let
       options = {
         "forZones" = mkOption {
           description = "forZones indicates the zone(s) this endpoint should be consumed by to enable topology aware routing.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.discovery.v1.ForZone")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.discovery.v1.ForZone" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -11644,7 +11671,8 @@ let
         };
         "ports" = mkOption {
           description = "ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates \"all ports\". Each slice may include a maximum of 100 ports.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.discovery.v1.EndpointPort")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.discovery.v1.EndpointPort" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -11773,7 +11801,8 @@ let
       options = {
         "forZones" = mkOption {
           description = "forZones indicates the zone(s) this endpoint should be consumed by to enable topology aware routing. May contain a maximum of 8 entries.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.discovery.v1beta1.ForZone")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.discovery.v1beta1.ForZone" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -11838,7 +11867,8 @@ let
         };
         "ports" = mkOption {
           description = "ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates \"all ports\". Each slice may include a maximum of 100 ports.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.discovery.v1beta1.EndpointPort")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.discovery.v1beta1.EndpointPort" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -14189,7 +14219,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute\n              the number of allowed disruptions. Therefore no disruptions are\n              allowed and the status of the condition will be False.\n- InsufficientPods: The number of pods are either at or below the number\n                    required by the PodDisruptionBudget. No disruptions are\n                    allowed and the status of the condition will be False.\n- SufficientPods: There are more pods than required by the PodDisruptionBudget.\n                  The condition will be True, and the number of allowed\n                  disruptions are provided by the disruptionsAllowed property.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type" [ ]));
           apply = attrsToList;
         };
         "currentHealthy" = mkOption {
@@ -14450,7 +14480,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute\n              the number of allowed disruptions. Therefore no disruptions are\n              allowed and the status of the condition will be False.\n- InsufficientPods: The number of pods are either at or below the number\n                    required by the PodDisruptionBudget. No disruptions are\n                    allowed and the status of the condition will be False.\n- SufficientPods: There are more pods than required by the PodDisruptionBudget.\n                  The condition will be True, and the number of allowed\n                  disruptions are provided by the disruptionsAllowed property.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type" [ ]));
           apply = attrsToList;
         };
         "currentHealthy" = mkOption {
@@ -14555,7 +14585,8 @@ let
         };
         "allowedCSIDrivers" = mkOption {
           description = "AllowedCSIDrivers is an allowlist of inline CSI drivers that must be explicitly set to be embedded within a pod spec. An empty value indicates that any CSI driver can be used for inline ephemeral volumes. This is a beta field, and is only honored if the API server enables the CSIInlineVolume feature gate.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.policy.v1beta1.AllowedCSIDriver")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.policy.v1beta1.AllowedCSIDriver" "name" [ ]));
+          apply = attrsToList;
         };
         "allowedCapabilities" = mkOption {
           description = "allowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field may be added at the pod author's discretion. You must not list a capability in both allowedCapabilities and requiredDropCapabilities.";
@@ -14839,7 +14870,8 @@ let
         };
         "subjects" = mkOption {
           description = "Subjects holds references to the objects the role applies to.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.rbac.v1.Subject")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.rbac.v1.Subject" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -14995,7 +15027,8 @@ let
         };
         "subjects" = mkOption {
           description = "Subjects holds references to the objects the role applies to.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.rbac.v1.Subject")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.rbac.v1.Subject" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -15186,7 +15219,8 @@ let
         };
         "subjects" = mkOption {
           description = "Subjects holds references to the objects the role applies to.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.rbac.v1alpha1.Subject")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.rbac.v1alpha1.Subject" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -15342,7 +15376,8 @@ let
         };
         "subjects" = mkOption {
           description = "Subjects holds references to the objects the role applies to.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.rbac.v1alpha1.Subject")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.rbac.v1alpha1.Subject" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -15533,7 +15568,8 @@ let
         };
         "subjects" = mkOption {
           description = "Subjects holds references to the objects the role applies to.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.rbac.v1beta1.Subject")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.rbac.v1beta1.Subject" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -15689,7 +15725,8 @@ let
         };
         "subjects" = mkOption {
           description = "Subjects holds references to the objects the role applies to.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.rbac.v1beta1.Subject")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.rbac.v1beta1.Subject" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -16222,7 +16259,7 @@ let
       options = {
         "drivers" = mkOption {
           description = "drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.";
-          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1.CSINodeDriver" "name");
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1.CSINodeDriver" "name" [ ]);
           apply = attrsToList;
         };
       };
@@ -16926,7 +16963,7 @@ let
       options = {
         "drivers" = mkOption {
           description = "drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.";
-          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1beta1.CSINodeDriver" "name");
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1beta1.CSINodeDriver" "name" [ ]);
           apply = attrsToList;
         };
       };
@@ -17498,7 +17535,8 @@ let
         };
         "versions" = mkOption {
           description = "versions is the list of all API versions of the defined custom resource. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is \"kube-like\", it will sort above non \"kube-like\" version strings, which are ordered lexicographically. \"Kube-like\" versions start with a \"v\", then are followed by a number (the major version), then optionally the string \"alpha\" or \"beta\" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.";
-          type = (types.listOf (submoduleOf "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion"));
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion" "name" [ ]);
+          apply = attrsToList;
         };
       };
 
@@ -17539,7 +17577,8 @@ let
       options = {
         "additionalPrinterColumns" = mkOption {
           description = "additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. If no columns are specified, a single column displaying the age of the custom resource is used.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition" "name" [ ]));
+          apply = attrsToList;
         };
         "deprecated" = mkOption {
           description = "deprecated indicates this version of the custom resource API is deprecated. When set to true, API requests to this version receive a warning header in the server response. Defaults to false.";
@@ -18161,7 +18200,8 @@ let
       options = {
         "additionalPrinterColumns" = mkOption {
           description = "additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. If present, this field configures columns for all versions. Top-level and per-version columns are mutually exclusive. If no top-level or per-version columns are specified, a single column displaying the age of the custom resource is used.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceColumnDefinition")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceColumnDefinition" "name" [ ]));
+          apply = attrsToList;
         };
         "conversion" = mkOption {
           description = "conversion defines conversion settings for the CRD.";
@@ -18197,7 +18237,8 @@ let
         };
         "versions" = mkOption {
           description = "versions is the list of all API versions of the defined custom resource. Optional if `version` is specified. The name of the first item in the `versions` list must match the `version` field if `version` and `versions` are both specified. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is \"kube-like\", it will sort above non \"kube-like\" version strings, which are ordered lexicographically. \"Kube-like\" versions start with a \"v\", then are followed by a number (the major version), then optionally the string \"alpha\" or \"beta\" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionVersion")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionVersion" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -18243,7 +18284,8 @@ let
       options = {
         "additionalPrinterColumns" = mkOption {
           description = "additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. Top-level and per-version columns are mutually exclusive. Per-version columns must not all be set to identical values (top-level columns should be used instead). If no top-level or per-version columns are specified, a single column displaying the age of the custom resource is used.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceColumnDefinition")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceColumnDefinition" "name" [ ]));
+          apply = attrsToList;
         };
         "deprecated" = mkOption {
           description = "deprecated indicates this version of the custom resource API is deprecated. When set to true, API requests to this version receive a warning header in the server response. Defaults to false.";
@@ -18694,7 +18736,8 @@ let
         };
         "groups" = mkOption {
           description = "groups is a list of APIGroup.";
-          type = (types.listOf (submoduleOf "io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"));
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup" "name" [ ]);
+          apply = attrsToList;
         };
         "kind" = mkOption {
           description = "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds";
@@ -18781,7 +18824,8 @@ let
         };
         "resources" = mkOption {
           description = "resources contains the name of the resources and if they are namespaced.";
-          type = (types.listOf (submoduleOf "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"));
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource" "name" [ ]);
+          apply = attrsToList;
         };
       };
 
@@ -19085,7 +19129,7 @@ let
         };
         "ownerReferences" = mkOption {
           description = "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference" "uid"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference" "uid" [ ]));
           apply = attrsToList;
         };
         "resourceVersion" = mkOption {
@@ -19522,7 +19566,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Current service state of apiService.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition" "type" [ ]));
           apply = attrsToList;
         };
       };
@@ -19703,7 +19747,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Current service state of apiService.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1beta1.APIServiceCondition" "type" [ ]));
           apply = attrsToList;
         };
       };

--- a/modules/generated/v1.23.nix
+++ b/modules/generated/v1.23.nix
@@ -66,14 +66,24 @@ let
 
   mkOptionDefault = mkOverride 1001;
 
-  # todo: can we use mkOrder
-  mergeValuesByKey = mergeKey: values:
+  mergeValuesByKey = attrMergeKey: listMergeKeys: values:
     listToAttrs (imap0
       (i: value: nameValuePair
         (
-          if isAttrs value.${mergeKey}
-          then toString value.${mergeKey}.content
-          else (toString value.${mergeKey})
+          if hasAttr attrMergeKey value
+          then
+            if isAttrs value.${attrMergeKey}
+            then toString value.${attrMergeKey}.content
+            else (toString value.${attrMergeKey})
+          else
+          # generate merge key for list elements if it's not present
+            "__kubenix_list_merge_key_" + (concatStringsSep "" (map
+              (key:
+                if isAttrs value.${key}
+                then toString value.${key}.content
+                else (toString value.${key})
+              )
+              listMergeKeys))
         )
         (value // { _priority = i; }))
       values);
@@ -96,7 +106,12 @@ let
         _priority = mkOption { type = types.nullOr types.int; default = null; };
       };
       config = definitions."${ref}".config // {
-        ${mergeKey} = mkOverride 1002 (convertName name);
+        ${mergeKey} = mkOverride 1002 (
+          # use name as mergeKey only if it is not coming from mergeValuesByKey
+          if (!hasPrefix "__kubenix_list_merge_key_" name)
+          then convertName name
+          else null
+        );
       };
     });
 
@@ -119,10 +134,10 @@ let
       ];
     });
 
-  coerceAttrsOfSubmodulesToListByKey = ref: mergeKey: (types.coercedTo
+  coerceAttrsOfSubmodulesToListByKey = ref: attrMergeKey: listMergeKeys: (types.coercedTo
     (types.listOf (submoduleOf ref))
-    (mergeValuesByKey mergeKey)
-    (types.attrsOf (submoduleWithMergeOf ref mergeKey))
+    (mergeValuesByKey attrMergeKey listMergeKeys)
+    (types.attrsOf (submoduleWithMergeOf ref attrMergeKey))
   );
 
   definitions = {
@@ -204,7 +219,7 @@ let
         };
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.MutatingWebhook" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.MutatingWebhook" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -383,7 +398,7 @@ let
         };
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.ValidatingWebhook" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.ValidatingWebhook" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -803,7 +818,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a DaemonSet's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DaemonSetCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DaemonSetCondition" "type" [ ]));
           apply = attrsToList;
         };
         "currentNumberScheduled" = mkOption {
@@ -1034,7 +1049,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a deployment's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DeploymentCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DeploymentCondition" "type" [ ]));
           apply = attrsToList;
         };
         "observedGeneration" = mkOption {
@@ -1227,7 +1242,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replica set's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.ReplicaSetCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.ReplicaSetCondition" "type" [ ]));
           apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
@@ -1500,7 +1515,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a statefulset's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.StatefulSetCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.StatefulSetCondition" "type" [ ]));
           apply = attrsToList;
         };
         "currentReplicas" = mkOption {
@@ -2683,7 +2698,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "conditions is the set of conditions required for this autoscaler to scale its target, and indicates whether or not those conditions are met.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition" "type" [ ]));
           apply = attrsToList;
         };
         "currentMetrics" = mkOption {
@@ -4218,7 +4233,8 @@ let
       options = {
         "active" = mkOption {
           description = "A list of pointers to currently running jobs.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ObjectReference")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name" [ ]));
+          apply = attrsToList;
         };
         "lastScheduleTime" = mkOption {
           description = "Information when was the last time the job was successfully scheduled.";
@@ -4416,7 +4432,7 @@ let
         };
         "conditions" = mkOption {
           description = "The latest available observations of an object's current state. When a Job fails, one of the conditions will have type \"Failed\" and status true. When a Job is suspended, one of the conditions will have type \"Suspended\" and status true; when the Job is resumed, the status of this condition will become false. When a Job is completed, one of the conditions will have type \"Complete\" and status true. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.batch.v1.JobCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.batch.v1.JobCondition" "type" [ ]));
           apply = attrsToList;
         };
         "failed" = mkOption {
@@ -4607,7 +4623,8 @@ let
       options = {
         "active" = mkOption {
           description = "A list of pointers to currently running jobs.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ObjectReference")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name" [ ]));
+          apply = attrsToList;
         };
         "lastScheduleTime" = mkOption {
           description = "Information when was the last time the job was successfully scheduled.";
@@ -5394,7 +5411,7 @@ let
         };
         "conditions" = mkOption {
           description = "List of component conditions observed";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ComponentCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ComponentCondition" "type" [ ]));
           apply = attrsToList;
         };
         "kind" = mkOption {
@@ -5658,7 +5675,7 @@ let
         };
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name" [ ]));
           apply = attrsToList;
         };
         "envFrom" = mkOption {
@@ -5687,7 +5704,7 @@ let
         };
         "ports" = mkOption {
           description = "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "name" [ "containerPort" "protocol" ]));
           apply = attrsToList;
         };
         "readinessProbe" = mkOption {
@@ -5728,12 +5745,12 @@ let
         };
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath" [ ]));
           apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath" [ ]));
           apply = attrsToList;
         };
         "workingDir" = mkOption {
@@ -6144,7 +6161,8 @@ let
         };
         "ports" = mkOption {
           description = "Port numbers available on the related IP addresses.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.EndpointPort")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EndpointPort" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -6307,7 +6325,7 @@ let
         };
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name" [ ]));
           apply = attrsToList;
         };
         "envFrom" = mkOption {
@@ -6336,7 +6354,7 @@ let
         };
         "ports" = mkOption {
           description = "Ports are not allowed for ephemeral containers.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "name" [ "containerPort" "protocol" ]));
           apply = attrsToList;
         };
         "readinessProbe" = mkOption {
@@ -6381,12 +6399,12 @@ let
         };
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath" [ ]));
           apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath" [ ]));
           apply = attrsToList;
         };
         "workingDir" = mkOption {
@@ -6869,7 +6887,8 @@ let
         };
         "httpHeaders" = mkOption {
           description = "Custom headers to set in the request. HTTP allows repeated headers.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.HTTPHeader")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HTTPHeader" "name" [ ]));
+          apply = attrsToList;
         };
         "path" = mkOption {
           description = "Path to access on the HTTP server.";
@@ -7467,7 +7486,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Represents the latest available observations of a namespace's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NamespaceCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NamespaceCondition" "type" [ ]));
           apply = attrsToList;
         };
         "phase" = mkOption {
@@ -7788,7 +7807,7 @@ let
       options = {
         "addresses" = mkOption {
           description = "List of addresses reachable to the node. Queried from cloud provider, if available. More info: https://kubernetes.io/docs/concepts/nodes/node/#addresses Note: This field is declared as mergeable, but the merge key is not sufficiently unique, which can cause data corruption when it is merged. Callers should instead use a full-replacement patch. See http://pr.k8s.io/79391 for an example.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeAddress" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeAddress" "type" [ ]));
           apply = attrsToList;
         };
         "allocatable" = mkOption {
@@ -7801,7 +7820,7 @@ let
         };
         "conditions" = mkOption {
           description = "Conditions is an array of current observed node conditions. More info: https://kubernetes.io/docs/concepts/nodes/node/#condition";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeCondition" "type" [ ]));
           apply = attrsToList;
         };
         "config" = mkOption {
@@ -7826,7 +7845,8 @@ let
         };
         "volumesAttached" = mkOption {
           description = "List of volumes that are attached to the node.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.AttachedVolume")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.AttachedVolume" "name" [ ]));
+          apply = attrsToList;
         };
         "volumesInUse" = mkOption {
           description = "List of attachable volumes in use (mounted) by the node.";
@@ -8167,7 +8187,7 @@ let
         };
         "conditions" = mkOption {
           description = "Current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PersistentVolumeClaimCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PersistentVolumeClaimCondition" "type" [ ]));
           apply = attrsToList;
         };
         "phase" = mkOption {
@@ -8613,7 +8633,8 @@ let
         };
         "options" = mkOption {
           description = "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.PodDNSConfigOption")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodDNSConfigOption" "name" [ ]));
+          apply = attrsToList;
         };
         "searches" = mkOption {
           description = "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.";
@@ -8756,7 +8777,8 @@ let
         };
         "sysctls" = mkOption {
           description = "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.Sysctl")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Sysctl" "name" [ ]));
+          apply = attrsToList;
         };
         "windowsOptions" = mkOption {
           description = "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.";
@@ -8796,7 +8818,7 @@ let
         };
         "containers" = mkOption {
           description = "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.";
-          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name");
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name" [ ]);
           apply = attrsToList;
         };
         "dnsConfig" = mkOption {
@@ -8813,12 +8835,12 @@ let
         };
         "ephemeralContainers" = mkOption {
           description = "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is beta-level and available on clusters that haven't disabled the EphemeralContainers feature gate.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name" [ ]));
           apply = attrsToList;
         };
         "hostAliases" = mkOption {
           description = "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HostAlias" "ip"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HostAlias" "ip" [ ]));
           apply = attrsToList;
         };
         "hostIPC" = mkOption {
@@ -8839,12 +8861,12 @@ let
         };
         "imagePullSecrets" = mkOption {
           description = "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. For example, in the case of docker, only DockerConfig type secrets are honored. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name" [ ]));
           apply = attrsToList;
         };
         "initContainers" = mkOption {
           description = "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name" [ ]));
           apply = attrsToList;
         };
         "nodeName" = mkOption {
@@ -8925,12 +8947,11 @@ let
         };
         "topologySpreadConstraints" = mkOption {
           description = "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.TopologySpreadConstraint" "topologyKey"));
-          apply = attrsToList;
+          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.TopologySpreadConstraint")));
         };
         "volumes" = mkOption {
           description = "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Volume" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Volume" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -8980,16 +9001,18 @@ let
       options = {
         "conditions" = mkOption {
           description = "Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodCondition" "type" [ ]));
           apply = attrsToList;
         };
         "containerStatuses" = mkOption {
           description = "The list has one entry per container in the manifest. Each entry is currently the output of `docker inspect`. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ContainerStatus")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerStatus" "name" [ ]));
+          apply = attrsToList;
         };
         "ephemeralContainerStatuses" = mkOption {
           description = "Status for any ephemeral containers that have run in this pod. This field is beta-level and available on clusters that haven't disabled the EphemeralContainers feature gate.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ContainerStatus")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerStatus" "name" [ ]));
+          apply = attrsToList;
         };
         "hostIP" = mkOption {
           description = "IP address of the host to which the pod is assigned. Empty if not yet scheduled.";
@@ -8997,7 +9020,8 @@ let
         };
         "initContainerStatuses" = mkOption {
           description = "The list has one entry per init container in the manifest. The most recent successful init container will have ready = true, the most recently started container will have startTime set. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ContainerStatus")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerStatus" "name" [ ]));
+          apply = attrsToList;
         };
         "message" = mkOption {
           description = "A human readable message indicating details about why the pod is in this condition.";
@@ -9017,7 +9041,7 @@ let
         };
         "podIPs" = mkOption {
           description = "podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list is empty if no IPs have been allocated yet.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodIP" "ip"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodIP" "ip" [ ]));
           apply = attrsToList;
         };
         "qosClass" = mkOption {
@@ -9545,7 +9569,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replication controller's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ReplicationControllerCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ReplicationControllerCondition" "type" [ ]));
           apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
@@ -10236,7 +10260,8 @@ let
         };
         "imagePullSecrets" = mkOption {
           description = "ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.LocalObjectReference")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name" [ ]));
+          apply = attrsToList;
         };
         "kind" = mkOption {
           description = "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds";
@@ -10248,7 +10273,7 @@ let
         };
         "secrets" = mkOption {
           description = "Secrets is the list of secrets allowed to be used by pods running using this ServiceAccount. More info: https://kubernetes.io/docs/concepts/configuration/secret";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -10442,7 +10467,7 @@ let
         };
         "ports" = mkOption {
           description = "The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ServicePort" "port"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ServicePort" "name" [ "port" "protocol" ]));
           apply = attrsToList;
         };
         "publishNotReadyAddresses" = mkOption {
@@ -10496,7 +10521,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Current service state";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type" [ ]));
           apply = attrsToList;
         };
         "loadBalancer" = mkOption {
@@ -11192,7 +11217,8 @@ let
       options = {
         "forZones" = mkOption {
           description = "forZones indicates the zone(s) this endpoint should be consumed by to enable topology aware routing.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.discovery.v1.ForZone")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.discovery.v1.ForZone" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -11257,7 +11283,8 @@ let
         };
         "ports" = mkOption {
           description = "ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates \"all ports\". Each slice may include a maximum of 100 ports.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.discovery.v1.EndpointPort")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.discovery.v1.EndpointPort" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -11386,7 +11413,8 @@ let
       options = {
         "forZones" = mkOption {
           description = "forZones indicates the zone(s) this endpoint should be consumed by to enable topology aware routing. May contain a maximum of 8 entries.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.discovery.v1beta1.ForZone")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.discovery.v1beta1.ForZone" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -11451,7 +11479,8 @@ let
         };
         "ports" = mkOption {
           description = "ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates \"all ports\". Each slice may include a maximum of 100 ports.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.discovery.v1beta1.EndpointPort")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.discovery.v1beta1.EndpointPort" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -13808,7 +13837,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute\n              the number of allowed disruptions. Therefore no disruptions are\n              allowed and the status of the condition will be False.\n- InsufficientPods: The number of pods are either at or below the number\n                    required by the PodDisruptionBudget. No disruptions are\n                    allowed and the status of the condition will be False.\n- SufficientPods: There are more pods than required by the PodDisruptionBudget.\n                  The condition will be True, and the number of allowed\n                  disruptions are provided by the disruptionsAllowed property.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type" [ ]));
           apply = attrsToList;
         };
         "currentHealthy" = mkOption {
@@ -14039,7 +14068,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute\n              the number of allowed disruptions. Therefore no disruptions are\n              allowed and the status of the condition will be False.\n- InsufficientPods: The number of pods are either at or below the number\n                    required by the PodDisruptionBudget. No disruptions are\n                    allowed and the status of the condition will be False.\n- SufficientPods: There are more pods than required by the PodDisruptionBudget.\n                  The condition will be True, and the number of allowed\n                  disruptions are provided by the disruptionsAllowed property.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type" [ ]));
           apply = attrsToList;
         };
         "currentHealthy" = mkOption {
@@ -14144,7 +14173,8 @@ let
         };
         "allowedCSIDrivers" = mkOption {
           description = "AllowedCSIDrivers is an allowlist of inline CSI drivers that must be explicitly set to be embedded within a pod spec. An empty value indicates that any CSI driver can be used for inline ephemeral volumes. This is a beta field, and is only honored if the API server enables the CSIInlineVolume feature gate.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.policy.v1beta1.AllowedCSIDriver")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.policy.v1beta1.AllowedCSIDriver" "name" [ ]));
+          apply = attrsToList;
         };
         "allowedCapabilities" = mkOption {
           description = "allowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field may be added at the pod author's discretion. You must not list a capability in both allowedCapabilities and requiredDropCapabilities.";
@@ -14428,7 +14458,8 @@ let
         };
         "subjects" = mkOption {
           description = "Subjects holds references to the objects the role applies to.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.rbac.v1.Subject")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.rbac.v1.Subject" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -14584,7 +14615,8 @@ let
         };
         "subjects" = mkOption {
           description = "Subjects holds references to the objects the role applies to.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.rbac.v1.Subject")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.rbac.v1.Subject" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -14971,7 +15003,7 @@ let
       options = {
         "drivers" = mkOption {
           description = "drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.";
-          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1.CSINodeDriver" "name");
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1.CSINodeDriver" "name" [ ]);
           apply = attrsToList;
         };
       };
@@ -15616,7 +15648,8 @@ let
         };
         "versions" = mkOption {
           description = "versions is the list of all API versions of the defined custom resource. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is \"kube-like\", it will sort above non \"kube-like\" version strings, which are ordered lexicographically. \"Kube-like\" versions start with a \"v\", then are followed by a number (the major version), then optionally the string \"alpha\" or \"beta\" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.";
-          type = (types.listOf (submoduleOf "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion"));
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion" "name" [ ]);
+          apply = attrsToList;
         };
       };
 
@@ -15657,7 +15690,8 @@ let
       options = {
         "additionalPrinterColumns" = mkOption {
           description = "additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. If no columns are specified, a single column displaying the age of the custom resource is used.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition" "name" [ ]));
+          apply = attrsToList;
         };
         "deprecated" = mkOption {
           description = "deprecated indicates this version of the custom resource API is deprecated. When set to true, API requests to this version receive a warning header in the server response. Defaults to false.";
@@ -15956,7 +15990,7 @@ let
         };
         "x-kubernetes-validations" = mkOption {
           description = "x-kubernetes-validations describes a list of validation rules written in the CEL expression language. This field is an alpha-level. Using this field requires the feature gate `CustomResourceValidationExpressions` to be enabled.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule" "rule"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule" "rule" [ ]));
           apply = attrsToList;
         };
       };
@@ -16152,7 +16186,8 @@ let
         };
         "groups" = mkOption {
           description = "groups is a list of APIGroup.";
-          type = (types.listOf (submoduleOf "io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"));
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup" "name" [ ]);
+          apply = attrsToList;
         };
         "kind" = mkOption {
           description = "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds";
@@ -16239,7 +16274,8 @@ let
         };
         "resources" = mkOption {
           description = "resources contains the name of the resources and if they are namespaced.";
-          type = (types.listOf (submoduleOf "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"));
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource" "name" [ ]);
+          apply = attrsToList;
         };
       };
 
@@ -16548,7 +16584,7 @@ let
         };
         "ownerReferences" = mkOption {
           description = "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference" "uid"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference" "uid" [ ]));
           apply = attrsToList;
         };
         "resourceVersion" = mkOption {
@@ -16985,7 +17021,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Current service state of apiService.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition" "type" [ ]));
           apply = attrsToList;
         };
       };

--- a/modules/generated/v1.24.nix
+++ b/modules/generated/v1.24.nix
@@ -66,14 +66,24 @@ let
 
   mkOptionDefault = mkOverride 1001;
 
-  # todo: can we use mkOrder
-  mergeValuesByKey = mergeKey: values:
+  mergeValuesByKey = attrMergeKey: listMergeKeys: values:
     listToAttrs (imap0
       (i: value: nameValuePair
         (
-          if isAttrs value.${mergeKey}
-          then toString value.${mergeKey}.content
-          else (toString value.${mergeKey})
+          if hasAttr attrMergeKey value
+          then
+            if isAttrs value.${attrMergeKey}
+            then toString value.${attrMergeKey}.content
+            else (toString value.${attrMergeKey})
+          else
+          # generate merge key for list elements if it's not present
+            "__kubenix_list_merge_key_" + (concatStringsSep "" (map
+              (key:
+                if isAttrs value.${key}
+                then toString value.${key}.content
+                else (toString value.${key})
+              )
+              listMergeKeys))
         )
         (value // { _priority = i; }))
       values);
@@ -96,7 +106,12 @@ let
         _priority = mkOption { type = types.nullOr types.int; default = null; };
       };
       config = definitions."${ref}".config // {
-        ${mergeKey} = mkOverride 1002 (convertName name);
+        ${mergeKey} = mkOverride 1002 (
+          # use name as mergeKey only if it is not coming from mergeValuesByKey
+          if (!hasPrefix "__kubenix_list_merge_key_" name)
+          then convertName name
+          else null
+        );
       };
     });
 
@@ -119,10 +134,10 @@ let
       ];
     });
 
-  coerceAttrsOfSubmodulesToListByKey = ref: mergeKey: (types.coercedTo
+  coerceAttrsOfSubmodulesToListByKey = ref: attrMergeKey: listMergeKeys: (types.coercedTo
     (types.listOf (submoduleOf ref))
-    (mergeValuesByKey mergeKey)
-    (types.attrsOf (submoduleWithMergeOf ref mergeKey))
+    (mergeValuesByKey attrMergeKey listMergeKeys)
+    (types.attrsOf (submoduleWithMergeOf ref attrMergeKey))
   );
 
   definitions = {
@@ -204,7 +219,7 @@ let
         };
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.MutatingWebhook" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.MutatingWebhook" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -383,7 +398,7 @@ let
         };
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.ValidatingWebhook" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.ValidatingWebhook" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -803,7 +818,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a DaemonSet's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DaemonSetCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DaemonSetCondition" "type" [ ]));
           apply = attrsToList;
         };
         "currentNumberScheduled" = mkOption {
@@ -1034,7 +1049,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a deployment's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DeploymentCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DeploymentCondition" "type" [ ]));
           apply = attrsToList;
         };
         "observedGeneration" = mkOption {
@@ -1227,7 +1242,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replica set's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.ReplicaSetCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.ReplicaSetCondition" "type" [ ]));
           apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
@@ -1505,7 +1520,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a statefulset's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.StatefulSetCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.StatefulSetCondition" "type" [ ]));
           apply = attrsToList;
         };
         "currentReplicas" = mkOption {
@@ -2688,7 +2703,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "conditions is the set of conditions required for this autoscaler to scale its target, and indicates whether or not those conditions are met.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition" "type" [ ]));
           apply = attrsToList;
         };
         "currentMetrics" = mkOption {
@@ -4228,7 +4243,8 @@ let
       options = {
         "active" = mkOption {
           description = "A list of pointers to currently running jobs.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ObjectReference")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name" [ ]));
+          apply = attrsToList;
         };
         "lastScheduleTime" = mkOption {
           description = "Information when was the last time the job was successfully scheduled.";
@@ -4426,7 +4442,7 @@ let
         };
         "conditions" = mkOption {
           description = "The latest available observations of an object's current state. When a Job fails, one of the conditions will have type \"Failed\" and status true. When a Job is suspended, one of the conditions will have type \"Suspended\" and status true; when the Job is resumed, the status of this condition will become false. When a Job is completed, one of the conditions will have type \"Complete\" and status true. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.batch.v1.JobCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.batch.v1.JobCondition" "type" [ ]));
           apply = attrsToList;
         };
         "failed" = mkOption {
@@ -4622,7 +4638,8 @@ let
       options = {
         "active" = mkOption {
           description = "A list of pointers to currently running jobs.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ObjectReference")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name" [ ]));
+          apply = attrsToList;
         };
         "lastScheduleTime" = mkOption {
           description = "Information when was the last time the job was successfully scheduled.";
@@ -5409,7 +5426,7 @@ let
         };
         "conditions" = mkOption {
           description = "List of component conditions observed";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ComponentCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ComponentCondition" "type" [ ]));
           apply = attrsToList;
         };
         "kind" = mkOption {
@@ -5673,7 +5690,7 @@ let
         };
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name" [ ]));
           apply = attrsToList;
         };
         "envFrom" = mkOption {
@@ -5702,7 +5719,7 @@ let
         };
         "ports" = mkOption {
           description = "List of ports to expose from the container. Exposing a port here gives the system additional information about the network connections a container uses, but is primarily informational. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "name" [ "containerPort" "protocol" ]));
           apply = attrsToList;
         };
         "readinessProbe" = mkOption {
@@ -5743,12 +5760,12 @@ let
         };
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath" [ ]));
           apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath" [ ]));
           apply = attrsToList;
         };
         "workingDir" = mkOption {
@@ -6159,7 +6176,8 @@ let
         };
         "ports" = mkOption {
           description = "Port numbers available on the related IP addresses.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.EndpointPort")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EndpointPort" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -6322,7 +6340,7 @@ let
         };
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name" [ ]));
           apply = attrsToList;
         };
         "envFrom" = mkOption {
@@ -6351,7 +6369,7 @@ let
         };
         "ports" = mkOption {
           description = "Ports are not allowed for ephemeral containers.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "name" [ "containerPort" "protocol" ]));
           apply = attrsToList;
         };
         "readinessProbe" = mkOption {
@@ -6396,12 +6414,12 @@ let
         };
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath" [ ]));
           apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath" [ ]));
           apply = attrsToList;
         };
         "workingDir" = mkOption {
@@ -6884,7 +6902,8 @@ let
         };
         "httpHeaders" = mkOption {
           description = "Custom headers to set in the request. HTTP allows repeated headers.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.HTTPHeader")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HTTPHeader" "name" [ ]));
+          apply = attrsToList;
         };
         "path" = mkOption {
           description = "Path to access on the HTTP server.";
@@ -7482,7 +7501,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Represents the latest available observations of a namespace's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NamespaceCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NamespaceCondition" "type" [ ]));
           apply = attrsToList;
         };
         "phase" = mkOption {
@@ -7803,7 +7822,7 @@ let
       options = {
         "addresses" = mkOption {
           description = "List of addresses reachable to the node. Queried from cloud provider, if available. More info: https://kubernetes.io/docs/concepts/nodes/node/#addresses Note: This field is declared as mergeable, but the merge key is not sufficiently unique, which can cause data corruption when it is merged. Callers should instead use a full-replacement patch. See http://pr.k8s.io/79391 for an example.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeAddress" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeAddress" "type" [ ]));
           apply = attrsToList;
         };
         "allocatable" = mkOption {
@@ -7816,7 +7835,7 @@ let
         };
         "conditions" = mkOption {
           description = "Conditions is an array of current observed node conditions. More info: https://kubernetes.io/docs/concepts/nodes/node/#condition";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeCondition" "type" [ ]));
           apply = attrsToList;
         };
         "config" = mkOption {
@@ -7841,7 +7860,8 @@ let
         };
         "volumesAttached" = mkOption {
           description = "List of volumes that are attached to the node.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.AttachedVolume")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.AttachedVolume" "name" [ ]));
+          apply = attrsToList;
         };
         "volumesInUse" = mkOption {
           description = "List of attachable volumes in use (mounted) by the node.";
@@ -8182,7 +8202,7 @@ let
         };
         "conditions" = mkOption {
           description = "conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PersistentVolumeClaimCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PersistentVolumeClaimCondition" "type" [ ]));
           apply = attrsToList;
         };
         "phase" = mkOption {
@@ -8628,7 +8648,8 @@ let
         };
         "options" = mkOption {
           description = "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.PodDNSConfigOption")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodDNSConfigOption" "name" [ ]));
+          apply = attrsToList;
         };
         "searches" = mkOption {
           description = "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.";
@@ -8771,7 +8792,8 @@ let
         };
         "sysctls" = mkOption {
           description = "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.Sysctl")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Sysctl" "name" [ ]));
+          apply = attrsToList;
         };
         "windowsOptions" = mkOption {
           description = "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.";
@@ -8811,7 +8833,7 @@ let
         };
         "containers" = mkOption {
           description = "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.";
-          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name");
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name" [ ]);
           apply = attrsToList;
         };
         "dnsConfig" = mkOption {
@@ -8828,12 +8850,12 @@ let
         };
         "ephemeralContainers" = mkOption {
           description = "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource. This field is beta-level and available on clusters that haven't disabled the EphemeralContainers feature gate.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name" [ ]));
           apply = attrsToList;
         };
         "hostAliases" = mkOption {
           description = "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HostAlias" "ip"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HostAlias" "ip" [ ]));
           apply = attrsToList;
         };
         "hostIPC" = mkOption {
@@ -8854,12 +8876,12 @@ let
         };
         "imagePullSecrets" = mkOption {
           description = "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name" [ ]));
           apply = attrsToList;
         };
         "initContainers" = mkOption {
           description = "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name" [ ]));
           apply = attrsToList;
         };
         "nodeName" = mkOption {
@@ -8940,12 +8962,11 @@ let
         };
         "topologySpreadConstraints" = mkOption {
           description = "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.TopologySpreadConstraint" "topologyKey"));
-          apply = attrsToList;
+          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.TopologySpreadConstraint")));
         };
         "volumes" = mkOption {
           description = "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Volume" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Volume" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -8995,16 +9016,18 @@ let
       options = {
         "conditions" = mkOption {
           description = "Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodCondition" "type" [ ]));
           apply = attrsToList;
         };
         "containerStatuses" = mkOption {
           description = "The list has one entry per container in the manifest. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ContainerStatus")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerStatus" "name" [ ]));
+          apply = attrsToList;
         };
         "ephemeralContainerStatuses" = mkOption {
           description = "Status for any ephemeral containers that have run in this pod. This field is beta-level and available on clusters that haven't disabled the EphemeralContainers feature gate.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ContainerStatus")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerStatus" "name" [ ]));
+          apply = attrsToList;
         };
         "hostIP" = mkOption {
           description = "IP address of the host to which the pod is assigned. Empty if not yet scheduled.";
@@ -9012,7 +9035,8 @@ let
         };
         "initContainerStatuses" = mkOption {
           description = "The list has one entry per init container in the manifest. The most recent successful init container will have ready = true, the most recently started container will have startTime set. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ContainerStatus")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerStatus" "name" [ ]));
+          apply = attrsToList;
         };
         "message" = mkOption {
           description = "A human readable message indicating details about why the pod is in this condition.";
@@ -9032,7 +9056,7 @@ let
         };
         "podIPs" = mkOption {
           description = "podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list is empty if no IPs have been allocated yet.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodIP" "ip"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodIP" "ip" [ ]));
           apply = attrsToList;
         };
         "qosClass" = mkOption {
@@ -9560,7 +9584,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replication controller's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ReplicationControllerCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ReplicationControllerCondition" "type" [ ]));
           apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
@@ -10251,7 +10275,8 @@ let
         };
         "imagePullSecrets" = mkOption {
           description = "ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.LocalObjectReference")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name" [ ]));
+          apply = attrsToList;
         };
         "kind" = mkOption {
           description = "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds";
@@ -10263,7 +10288,7 @@ let
         };
         "secrets" = mkOption {
           description = "Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use. Pods are only limited to this list if this service account has a \"kubernetes.io/enforce-mountable-secrets\" annotation set to \"true\". This field should not be used to find auto-generated service account token secrets for use outside of pods. Instead, tokens can be requested directly using the TokenRequest API, or service account token secrets can be manually created. More info: https://kubernetes.io/docs/concepts/configuration/secret";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -10457,7 +10482,7 @@ let
         };
         "ports" = mkOption {
           description = "The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ServicePort" "port"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ServicePort" "name" [ "port" "protocol" ]));
           apply = attrsToList;
         };
         "publishNotReadyAddresses" = mkOption {
@@ -10511,7 +10536,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Current service state";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type" [ ]));
           apply = attrsToList;
         };
         "loadBalancer" = mkOption {
@@ -11212,7 +11237,8 @@ let
       options = {
         "forZones" = mkOption {
           description = "forZones indicates the zone(s) this endpoint should be consumed by to enable topology aware routing.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.discovery.v1.ForZone")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.discovery.v1.ForZone" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -11277,7 +11303,8 @@ let
         };
         "ports" = mkOption {
           description = "ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates \"all ports\". Each slice may include a maximum of 100 ports.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.discovery.v1.EndpointPort")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.discovery.v1.EndpointPort" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -11406,7 +11433,8 @@ let
       options = {
         "forZones" = mkOption {
           description = "forZones indicates the zone(s) this endpoint should be consumed by to enable topology aware routing. May contain a maximum of 8 entries.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.discovery.v1beta1.ForZone")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.discovery.v1beta1.ForZone" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -11471,7 +11499,8 @@ let
         };
         "ports" = mkOption {
           description = "ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates \"all ports\". Each slice may include a maximum of 100 ports.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.discovery.v1beta1.EndpointPort")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.discovery.v1beta1.EndpointPort" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -13371,7 +13400,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Conditions holds an array of metav1.Condition that describe the state of the NetworkPolicy. Current service state";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type" [ ]));
           apply = attrsToList;
         };
       };
@@ -13732,7 +13761,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute\n              the number of allowed disruptions. Therefore no disruptions are\n              allowed and the status of the condition will be False.\n- InsufficientPods: The number of pods are either at or below the number\n                    required by the PodDisruptionBudget. No disruptions are\n                    allowed and the status of the condition will be False.\n- SufficientPods: There are more pods than required by the PodDisruptionBudget.\n                  The condition will be True, and the number of allowed\n                  disruptions are provided by the disruptionsAllowed property.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type" [ ]));
           apply = attrsToList;
         };
         "currentHealthy" = mkOption {
@@ -13963,7 +13992,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute\n              the number of allowed disruptions. Therefore no disruptions are\n              allowed and the status of the condition will be False.\n- InsufficientPods: The number of pods are either at or below the number\n                    required by the PodDisruptionBudget. No disruptions are\n                    allowed and the status of the condition will be False.\n- SufficientPods: There are more pods than required by the PodDisruptionBudget.\n                  The condition will be True, and the number of allowed\n                  disruptions are provided by the disruptionsAllowed property.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type" [ ]));
           apply = attrsToList;
         };
         "currentHealthy" = mkOption {
@@ -14068,7 +14097,8 @@ let
         };
         "allowedCSIDrivers" = mkOption {
           description = "AllowedCSIDrivers is an allowlist of inline CSI drivers that must be explicitly set to be embedded within a pod spec. An empty value indicates that any CSI driver can be used for inline ephemeral volumes. This is a beta field, and is only honored if the API server enables the CSIInlineVolume feature gate.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.policy.v1beta1.AllowedCSIDriver")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.policy.v1beta1.AllowedCSIDriver" "name" [ ]));
+          apply = attrsToList;
         };
         "allowedCapabilities" = mkOption {
           description = "allowedCapabilities is a list of capabilities that can be requested to add to the container. Capabilities in this field may be added at the pod author's discretion. You must not list a capability in both allowedCapabilities and requiredDropCapabilities.";
@@ -14352,7 +14382,8 @@ let
         };
         "subjects" = mkOption {
           description = "Subjects holds references to the objects the role applies to.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.rbac.v1.Subject")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.rbac.v1.Subject" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -14508,7 +14539,8 @@ let
         };
         "subjects" = mkOption {
           description = "Subjects holds references to the objects the role applies to.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.rbac.v1.Subject")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.rbac.v1.Subject" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -14895,7 +14927,7 @@ let
       options = {
         "drivers" = mkOption {
           description = "drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.";
-          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1.CSINodeDriver" "name");
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1.CSINodeDriver" "name" [ ]);
           apply = attrsToList;
         };
       };
@@ -15540,7 +15572,8 @@ let
         };
         "versions" = mkOption {
           description = "versions is the list of all API versions of the defined custom resource. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is \"kube-like\", it will sort above non \"kube-like\" version strings, which are ordered lexicographically. \"Kube-like\" versions start with a \"v\", then are followed by a number (the major version), then optionally the string \"alpha\" or \"beta\" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.";
-          type = (types.listOf (submoduleOf "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion"));
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion" "name" [ ]);
+          apply = attrsToList;
         };
       };
 
@@ -15581,7 +15614,8 @@ let
       options = {
         "additionalPrinterColumns" = mkOption {
           description = "additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. If no columns are specified, a single column displaying the age of the custom resource is used.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition" "name" [ ]));
+          apply = attrsToList;
         };
         "deprecated" = mkOption {
           description = "deprecated indicates this version of the custom resource API is deprecated. When set to true, API requests to this version receive a warning header in the server response. Defaults to false.";
@@ -15880,7 +15914,7 @@ let
         };
         "x-kubernetes-validations" = mkOption {
           description = "x-kubernetes-validations describes a list of validation rules written in the CEL expression language. This field is an alpha-level. Using this field requires the feature gate `CustomResourceValidationExpressions` to be enabled.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule" "rule"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule" "rule" [ ]));
           apply = attrsToList;
         };
       };
@@ -16076,7 +16110,8 @@ let
         };
         "groups" = mkOption {
           description = "groups is a list of APIGroup.";
-          type = (types.listOf (submoduleOf "io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"));
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup" "name" [ ]);
+          apply = attrsToList;
         };
         "kind" = mkOption {
           description = "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds";
@@ -16163,7 +16198,8 @@ let
         };
         "resources" = mkOption {
           description = "resources contains the name of the resources and if they are namespaced.";
-          type = (types.listOf (submoduleOf "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"));
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource" "name" [ ]);
+          apply = attrsToList;
         };
       };
 
@@ -16472,7 +16508,7 @@ let
         };
         "ownerReferences" = mkOption {
           description = "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference" "uid"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference" "uid" [ ]));
           apply = attrsToList;
         };
         "resourceVersion" = mkOption {
@@ -16909,7 +16945,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Current service state of apiService.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition" "type" [ ]));
           apply = attrsToList;
         };
       };

--- a/modules/generated/v1.25.nix
+++ b/modules/generated/v1.25.nix
@@ -66,14 +66,24 @@ let
 
   mkOptionDefault = mkOverride 1001;
 
-  # todo: can we use mkOrder
-  mergeValuesByKey = mergeKey: values:
+  mergeValuesByKey = attrMergeKey: listMergeKeys: values:
     listToAttrs (imap0
       (i: value: nameValuePair
         (
-          if isAttrs value.${mergeKey}
-          then toString value.${mergeKey}.content
-          else (toString value.${mergeKey})
+          if hasAttr attrMergeKey value
+          then
+            if isAttrs value.${attrMergeKey}
+            then toString value.${attrMergeKey}.content
+            else (toString value.${attrMergeKey})
+          else
+          # generate merge key for list elements if it's not present
+            "__kubenix_list_merge_key_" + (concatStringsSep "" (map
+              (key:
+                if isAttrs value.${key}
+                then toString value.${key}.content
+                else (toString value.${key})
+              )
+              listMergeKeys))
         )
         (value // { _priority = i; }))
       values);
@@ -96,7 +106,12 @@ let
         _priority = mkOption { type = types.nullOr types.int; default = null; };
       };
       config = definitions."${ref}".config // {
-        ${mergeKey} = mkOverride 1002 (convertName name);
+        ${mergeKey} = mkOverride 1002 (
+          # use name as mergeKey only if it is not coming from mergeValuesByKey
+          if (!hasPrefix "__kubenix_list_merge_key_" name)
+          then convertName name
+          else null
+        );
       };
     });
 
@@ -119,10 +134,10 @@ let
       ];
     });
 
-  coerceAttrsOfSubmodulesToListByKey = ref: mergeKey: (types.coercedTo
+  coerceAttrsOfSubmodulesToListByKey = ref: attrMergeKey: listMergeKeys: (types.coercedTo
     (types.listOf (submoduleOf ref))
-    (mergeValuesByKey mergeKey)
-    (types.attrsOf (submoduleWithMergeOf ref mergeKey))
+    (mergeValuesByKey attrMergeKey listMergeKeys)
+    (types.attrsOf (submoduleWithMergeOf ref attrMergeKey))
   );
 
   definitions = {
@@ -204,7 +219,7 @@ let
         };
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.MutatingWebhook" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.MutatingWebhook" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -383,7 +398,7 @@ let
         };
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.ValidatingWebhook" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.ValidatingWebhook" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -803,7 +818,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a DaemonSet's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DaemonSetCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DaemonSetCondition" "type" [ ]));
           apply = attrsToList;
         };
         "currentNumberScheduled" = mkOption {
@@ -1034,7 +1049,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a deployment's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DeploymentCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DeploymentCondition" "type" [ ]));
           apply = attrsToList;
         };
         "observedGeneration" = mkOption {
@@ -1227,7 +1242,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replica set's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.ReplicaSetCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.ReplicaSetCondition" "type" [ ]));
           apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
@@ -1505,7 +1520,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a statefulset's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.StatefulSetCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.StatefulSetCondition" "type" [ ]));
           apply = attrsToList;
         };
         "currentReplicas" = mkOption {
@@ -2688,7 +2703,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "conditions is the set of conditions required for this autoscaler to scale its target, and indicates whether or not those conditions are met.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition" "type" [ ]));
           apply = attrsToList;
         };
         "currentMetrics" = mkOption {
@@ -3695,7 +3710,8 @@ let
       options = {
         "active" = mkOption {
           description = "A list of pointers to currently running jobs.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ObjectReference")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name" [ ]));
+          apply = attrsToList;
         };
         "lastScheduleTime" = mkOption {
           description = "Information when was the last time the job was successfully scheduled.";
@@ -3898,7 +3914,7 @@ let
         };
         "conditions" = mkOption {
           description = "The latest available observations of an object's current state. When a Job fails, one of the conditions will have type \"Failed\" and status true. When a Job is suspended, one of the conditions will have type \"Suspended\" and status true; when the Job is resumed, the status of this condition will become false. When a Job is completed, one of the conditions will have type \"Complete\" and status true. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.batch.v1.JobCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.batch.v1.JobCondition" "type" [ ]));
           apply = attrsToList;
         };
         "failed" = mkOption {
@@ -4805,7 +4821,7 @@ let
         };
         "conditions" = mkOption {
           description = "List of component conditions observed";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ComponentCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ComponentCondition" "type" [ ]));
           apply = attrsToList;
         };
         "kind" = mkOption {
@@ -5069,7 +5085,7 @@ let
         };
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name" [ ]));
           apply = attrsToList;
         };
         "envFrom" = mkOption {
@@ -5098,7 +5114,7 @@ let
         };
         "ports" = mkOption {
           description = "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "name" [ "containerPort" "protocol" ]));
           apply = attrsToList;
         };
         "readinessProbe" = mkOption {
@@ -5139,12 +5155,12 @@ let
         };
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath" [ ]));
           apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath" [ ]));
           apply = attrsToList;
         };
         "workingDir" = mkOption {
@@ -5555,7 +5571,8 @@ let
         };
         "ports" = mkOption {
           description = "Port numbers available on the related IP addresses.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.EndpointPort")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EndpointPort" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -5718,7 +5735,7 @@ let
         };
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name" [ ]));
           apply = attrsToList;
         };
         "envFrom" = mkOption {
@@ -5747,7 +5764,7 @@ let
         };
         "ports" = mkOption {
           description = "Ports are not allowed for ephemeral containers.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "name" [ "containerPort" "protocol" ]));
           apply = attrsToList;
         };
         "readinessProbe" = mkOption {
@@ -5792,12 +5809,12 @@ let
         };
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath" [ ]));
           apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath" [ ]));
           apply = attrsToList;
         };
         "workingDir" = mkOption {
@@ -6280,7 +6297,8 @@ let
         };
         "httpHeaders" = mkOption {
           description = "Custom headers to set in the request. HTTP allows repeated headers.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.HTTPHeader")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HTTPHeader" "name" [ ]));
+          apply = attrsToList;
         };
         "path" = mkOption {
           description = "Path to access on the HTTP server.";
@@ -6878,7 +6896,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Represents the latest available observations of a namespace's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NamespaceCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NamespaceCondition" "type" [ ]));
           apply = attrsToList;
         };
         "phase" = mkOption {
@@ -7199,7 +7217,7 @@ let
       options = {
         "addresses" = mkOption {
           description = "List of addresses reachable to the node. Queried from cloud provider, if available. More info: https://kubernetes.io/docs/concepts/nodes/node/#addresses Note: This field is declared as mergeable, but the merge key is not sufficiently unique, which can cause data corruption when it is merged. Callers should instead use a full-replacement patch. See http://pr.k8s.io/79391 for an example.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeAddress" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeAddress" "type" [ ]));
           apply = attrsToList;
         };
         "allocatable" = mkOption {
@@ -7212,7 +7230,7 @@ let
         };
         "conditions" = mkOption {
           description = "Conditions is an array of current observed node conditions. More info: https://kubernetes.io/docs/concepts/nodes/node/#condition";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeCondition" "type" [ ]));
           apply = attrsToList;
         };
         "config" = mkOption {
@@ -7237,7 +7255,8 @@ let
         };
         "volumesAttached" = mkOption {
           description = "List of volumes that are attached to the node.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.AttachedVolume")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.AttachedVolume" "name" [ ]));
+          apply = attrsToList;
         };
         "volumesInUse" = mkOption {
           description = "List of attachable volumes in use (mounted) by the node.";
@@ -7578,7 +7597,7 @@ let
         };
         "conditions" = mkOption {
           description = "conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PersistentVolumeClaimCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PersistentVolumeClaimCondition" "type" [ ]));
           apply = attrsToList;
         };
         "phase" = mkOption {
@@ -8024,7 +8043,8 @@ let
         };
         "options" = mkOption {
           description = "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.PodDNSConfigOption")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodDNSConfigOption" "name" [ ]));
+          apply = attrsToList;
         };
         "searches" = mkOption {
           description = "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.";
@@ -8167,7 +8187,8 @@ let
         };
         "sysctls" = mkOption {
           description = "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.Sysctl")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Sysctl" "name" [ ]));
+          apply = attrsToList;
         };
         "windowsOptions" = mkOption {
           description = "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.";
@@ -8207,7 +8228,7 @@ let
         };
         "containers" = mkOption {
           description = "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.";
-          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name");
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name" [ ]);
           apply = attrsToList;
         };
         "dnsConfig" = mkOption {
@@ -8224,12 +8245,12 @@ let
         };
         "ephemeralContainers" = mkOption {
           description = "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name" [ ]));
           apply = attrsToList;
         };
         "hostAliases" = mkOption {
           description = "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HostAlias" "ip"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HostAlias" "ip" [ ]));
           apply = attrsToList;
         };
         "hostIPC" = mkOption {
@@ -8254,12 +8275,12 @@ let
         };
         "imagePullSecrets" = mkOption {
           description = "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name" [ ]));
           apply = attrsToList;
         };
         "initContainers" = mkOption {
           description = "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name" [ ]));
           apply = attrsToList;
         };
         "nodeName" = mkOption {
@@ -8340,12 +8361,11 @@ let
         };
         "topologySpreadConstraints" = mkOption {
           description = "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.TopologySpreadConstraint" "topologyKey"));
-          apply = attrsToList;
+          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.TopologySpreadConstraint")));
         };
         "volumes" = mkOption {
           description = "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Volume" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Volume" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -8396,16 +8416,18 @@ let
       options = {
         "conditions" = mkOption {
           description = "Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodCondition" "type" [ ]));
           apply = attrsToList;
         };
         "containerStatuses" = mkOption {
           description = "The list has one entry per container in the manifest. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ContainerStatus")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerStatus" "name" [ ]));
+          apply = attrsToList;
         };
         "ephemeralContainerStatuses" = mkOption {
           description = "Status for any ephemeral containers that have run in this pod.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ContainerStatus")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerStatus" "name" [ ]));
+          apply = attrsToList;
         };
         "hostIP" = mkOption {
           description = "IP address of the host to which the pod is assigned. Empty if not yet scheduled.";
@@ -8413,7 +8435,8 @@ let
         };
         "initContainerStatuses" = mkOption {
           description = "The list has one entry per init container in the manifest. The most recent successful init container will have ready = true, the most recently started container will have startTime set. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ContainerStatus")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerStatus" "name" [ ]));
+          apply = attrsToList;
         };
         "message" = mkOption {
           description = "A human readable message indicating details about why the pod is in this condition.";
@@ -8433,7 +8456,7 @@ let
         };
         "podIPs" = mkOption {
           description = "podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list is empty if no IPs have been allocated yet.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodIP" "ip"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodIP" "ip" [ ]));
           apply = attrsToList;
         };
         "qosClass" = mkOption {
@@ -8961,7 +8984,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replication controller's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ReplicationControllerCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ReplicationControllerCondition" "type" [ ]));
           apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
@@ -9652,7 +9675,8 @@ let
         };
         "imagePullSecrets" = mkOption {
           description = "ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.LocalObjectReference")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name" [ ]));
+          apply = attrsToList;
         };
         "kind" = mkOption {
           description = "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds";
@@ -9664,7 +9688,7 @@ let
         };
         "secrets" = mkOption {
           description = "Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use. Pods are only limited to this list if this service account has a \"kubernetes.io/enforce-mountable-secrets\" annotation set to \"true\". This field should not be used to find auto-generated service account token secrets for use outside of pods. Instead, tokens can be requested directly using the TokenRequest API, or service account token secrets can be manually created. More info: https://kubernetes.io/docs/concepts/configuration/secret";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -9858,7 +9882,7 @@ let
         };
         "ports" = mkOption {
           description = "The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ServicePort" "port"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ServicePort" "name" [ "port" "protocol" ]));
           apply = attrsToList;
         };
         "publishNotReadyAddresses" = mkOption {
@@ -9912,7 +9936,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Current service state";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type" [ ]));
           apply = attrsToList;
         };
         "loadBalancer" = mkOption {
@@ -10628,7 +10652,8 @@ let
       options = {
         "forZones" = mkOption {
           description = "forZones indicates the zone(s) this endpoint should be consumed by to enable topology aware routing.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.discovery.v1.ForZone")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.discovery.v1.ForZone" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -10693,7 +10718,8 @@ let
         };
         "ports" = mkOption {
           description = "ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates \"all ports\". Each slice may include a maximum of 100 ports.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.discovery.v1.EndpointPort")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.discovery.v1.EndpointPort" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -12453,7 +12479,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Conditions holds an array of metav1.Condition that describe the state of the NetworkPolicy. Current service state";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type" [ ]));
           apply = attrsToList;
         };
       };
@@ -12799,7 +12825,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute\n              the number of allowed disruptions. Therefore no disruptions are\n              allowed and the status of the condition will be False.\n- InsufficientPods: The number of pods are either at or below the number\n                    required by the PodDisruptionBudget. No disruptions are\n                    allowed and the status of the condition will be False.\n- SufficientPods: There are more pods than required by the PodDisruptionBudget.\n                  The condition will be True, and the number of allowed\n                  disruptions are provided by the disruptionsAllowed property.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type" [ ]));
           apply = attrsToList;
         };
         "currentHealthy" = mkOption {
@@ -12907,7 +12933,8 @@ let
         };
         "subjects" = mkOption {
           description = "Subjects holds references to the objects the role applies to.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.rbac.v1.Subject")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.rbac.v1.Subject" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -13063,7 +13090,8 @@ let
         };
         "subjects" = mkOption {
           description = "Subjects holds references to the objects the role applies to.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.rbac.v1.Subject")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.rbac.v1.Subject" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -13455,7 +13483,7 @@ let
       options = {
         "drivers" = mkOption {
           description = "drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.";
-          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1.CSINodeDriver" "name");
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1.CSINodeDriver" "name" [ ]);
           apply = attrsToList;
         };
       };
@@ -14100,7 +14128,8 @@ let
         };
         "versions" = mkOption {
           description = "versions is the list of all API versions of the defined custom resource. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is \"kube-like\", it will sort above non \"kube-like\" version strings, which are ordered lexicographically. \"Kube-like\" versions start with a \"v\", then are followed by a number (the major version), then optionally the string \"alpha\" or \"beta\" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.";
-          type = (types.listOf (submoduleOf "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion"));
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion" "name" [ ]);
+          apply = attrsToList;
         };
       };
 
@@ -14141,7 +14170,8 @@ let
       options = {
         "additionalPrinterColumns" = mkOption {
           description = "additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. If no columns are specified, a single column displaying the age of the custom resource is used.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition" "name" [ ]));
+          apply = attrsToList;
         };
         "deprecated" = mkOption {
           description = "deprecated indicates this version of the custom resource API is deprecated. When set to true, API requests to this version receive a warning header in the server response. Defaults to false.";
@@ -14440,7 +14470,7 @@ let
         };
         "x-kubernetes-validations" = mkOption {
           description = "x-kubernetes-validations describes a list of validation rules written in the CEL expression language. This field is an alpha-level. Using this field requires the feature gate `CustomResourceValidationExpressions` to be enabled.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule" "rule"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule" "rule" [ ]));
           apply = attrsToList;
         };
       };
@@ -14636,7 +14666,8 @@ let
         };
         "groups" = mkOption {
           description = "groups is a list of APIGroup.";
-          type = (types.listOf (submoduleOf "io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"));
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup" "name" [ ]);
+          apply = attrsToList;
         };
         "kind" = mkOption {
           description = "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds";
@@ -14723,7 +14754,8 @@ let
         };
         "resources" = mkOption {
           description = "resources contains the name of the resources and if they are namespaced.";
-          type = (types.listOf (submoduleOf "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"));
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource" "name" [ ]);
+          apply = attrsToList;
         };
       };
 
@@ -15028,7 +15060,7 @@ let
         };
         "ownerReferences" = mkOption {
           description = "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference" "uid"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference" "uid" [ ]));
           apply = attrsToList;
         };
         "resourceVersion" = mkOption {
@@ -15464,7 +15496,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Current service state of apiService.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition" "type" [ ]));
           apply = attrsToList;
         };
       };

--- a/modules/generated/v1.26.nix
+++ b/modules/generated/v1.26.nix
@@ -66,14 +66,24 @@ let
 
   mkOptionDefault = mkOverride 1001;
 
-  # todo: can we use mkOrder
-  mergeValuesByKey = mergeKey: values:
+  mergeValuesByKey = attrMergeKey: listMergeKeys: values:
     listToAttrs (imap0
       (i: value: nameValuePair
         (
-          if isAttrs value.${mergeKey}
-          then toString value.${mergeKey}.content
-          else (toString value.${mergeKey})
+          if hasAttr attrMergeKey value
+          then
+            if isAttrs value.${attrMergeKey}
+            then toString value.${attrMergeKey}.content
+            else (toString value.${attrMergeKey})
+          else
+          # generate merge key for list elements if it's not present
+            "__kubenix_list_merge_key_" + (concatStringsSep "" (map
+              (key:
+                if isAttrs value.${key}
+                then toString value.${key}.content
+                else (toString value.${key})
+              )
+              listMergeKeys))
         )
         (value // { _priority = i; }))
       values);
@@ -96,7 +106,12 @@ let
         _priority = mkOption { type = types.nullOr types.int; default = null; };
       };
       config = definitions."${ref}".config // {
-        ${mergeKey} = mkOverride 1002 (convertName name);
+        ${mergeKey} = mkOverride 1002 (
+          # use name as mergeKey only if it is not coming from mergeValuesByKey
+          if (!hasPrefix "__kubenix_list_merge_key_" name)
+          then convertName name
+          else null
+        );
       };
     });
 
@@ -119,10 +134,10 @@ let
       ];
     });
 
-  coerceAttrsOfSubmodulesToListByKey = ref: mergeKey: (types.coercedTo
+  coerceAttrsOfSubmodulesToListByKey = ref: attrMergeKey: listMergeKeys: (types.coercedTo
     (types.listOf (submoduleOf ref))
-    (mergeValuesByKey mergeKey)
-    (types.attrsOf (submoduleWithMergeOf ref mergeKey))
+    (mergeValuesByKey attrMergeKey listMergeKeys)
+    (types.attrsOf (submoduleWithMergeOf ref attrMergeKey))
   );
 
   definitions = {
@@ -204,7 +219,7 @@ let
         };
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.MutatingWebhook" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.MutatingWebhook" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -383,7 +398,7 @@ let
         };
         "webhooks" = mkOption {
           description = "Webhooks is a list of webhooks and the affected resources and operations.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.ValidatingWebhook" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.admissionregistration.v1.ValidatingWebhook" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -1116,7 +1131,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a DaemonSet's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DaemonSetCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DaemonSetCondition" "type" [ ]));
           apply = attrsToList;
         };
         "currentNumberScheduled" = mkOption {
@@ -1347,7 +1362,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a deployment's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DeploymentCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.DeploymentCondition" "type" [ ]));
           apply = attrsToList;
         };
         "observedGeneration" = mkOption {
@@ -1540,7 +1555,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replica set's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.ReplicaSetCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.ReplicaSetCondition" "type" [ ]));
           apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
@@ -1838,7 +1853,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a statefulset's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.StatefulSetCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.apps.v1.StatefulSetCondition" "type" [ ]));
           apply = attrsToList;
         };
         "currentReplicas" = mkOption {
@@ -3066,7 +3081,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "conditions is the set of conditions required for this autoscaler to scale its target, and indicates whether or not those conditions are met.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.autoscaling.v2.HorizontalPodAutoscalerCondition" "type" [ ]));
           apply = attrsToList;
         };
         "currentMetrics" = mkOption {
@@ -3479,7 +3494,8 @@ let
       options = {
         "active" = mkOption {
           description = "A list of pointers to currently running jobs.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ObjectReference")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name" [ ]));
+          apply = attrsToList;
         };
         "lastScheduleTime" = mkOption {
           description = "Information when was the last time the job was successfully scheduled.";
@@ -3682,7 +3698,7 @@ let
         };
         "conditions" = mkOption {
           description = "The latest available observations of an object's current state. When a Job fails, one of the conditions will have type \"Failed\" and status true. When a Job is suspended, one of the conditions will have type \"Suspended\" and status true; when the Job is resumed, the status of this condition will become false. When a Job is completed, one of the conditions will have type \"Complete\" and status true. More info: https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.batch.v1.JobCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.batch.v1.JobCondition" "type" [ ]));
           apply = attrsToList;
         };
         "failed" = mkOption {
@@ -4609,7 +4625,7 @@ let
         };
         "conditions" = mkOption {
           description = "List of component conditions observed";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ComponentCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ComponentCondition" "type" [ ]));
           apply = attrsToList;
         };
         "kind" = mkOption {
@@ -4873,7 +4889,7 @@ let
         };
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name" [ ]));
           apply = attrsToList;
         };
         "envFrom" = mkOption {
@@ -4902,7 +4918,7 @@ let
         };
         "ports" = mkOption {
           description = "List of ports to expose from the container. Not specifying a port here DOES NOT prevent that port from being exposed. Any port which is listening on the default \"0.0.0.0\" address inside a container will be accessible from the network. Modifying this array with strategic merge patch may corrupt the data. For more information See https://github.com/kubernetes/kubernetes/issues/108255. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "name" [ "containerPort" "protocol" ]));
           apply = attrsToList;
         };
         "readinessProbe" = mkOption {
@@ -4943,12 +4959,12 @@ let
         };
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath" [ ]));
           apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath" [ ]));
           apply = attrsToList;
         };
         "workingDir" = mkOption {
@@ -5359,7 +5375,8 @@ let
         };
         "ports" = mkOption {
           description = "Port numbers available on the related IP addresses.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.EndpointPort")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EndpointPort" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -5522,7 +5539,7 @@ let
         };
         "env" = mkOption {
           description = "List of environment variables to set in the container. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EnvVar" "name" [ ]));
           apply = attrsToList;
         };
         "envFrom" = mkOption {
@@ -5551,7 +5568,7 @@ let
         };
         "ports" = mkOption {
           description = "Ports are not allowed for ephemeral containers.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "containerPort"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerPort" "name" [ "containerPort" "protocol" ]));
           apply = attrsToList;
         };
         "readinessProbe" = mkOption {
@@ -5596,12 +5613,12 @@ let
         };
         "volumeDevices" = mkOption {
           description = "volumeDevices is the list of block devices to be used by the container.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeDevice" "devicePath" [ ]));
           apply = attrsToList;
         };
         "volumeMounts" = mkOption {
           description = "Pod volumes to mount into the container's filesystem. Subpath mounts are not allowed for ephemeral containers. Cannot be updated.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.VolumeMount" "mountPath" [ ]));
           apply = attrsToList;
         };
         "workingDir" = mkOption {
@@ -6084,7 +6101,8 @@ let
         };
         "httpHeaders" = mkOption {
           description = "Custom headers to set in the request. HTTP allows repeated headers.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.HTTPHeader")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HTTPHeader" "name" [ ]));
+          apply = attrsToList;
         };
         "path" = mkOption {
           description = "Path to access on the HTTP server.";
@@ -6682,7 +6700,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Represents the latest available observations of a namespace's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NamespaceCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NamespaceCondition" "type" [ ]));
           apply = attrsToList;
         };
         "phase" = mkOption {
@@ -7003,7 +7021,7 @@ let
       options = {
         "addresses" = mkOption {
           description = "List of addresses reachable to the node. Queried from cloud provider, if available. More info: https://kubernetes.io/docs/concepts/nodes/node/#addresses Note: This field is declared as mergeable, but the merge key is not sufficiently unique, which can cause data corruption when it is merged. Callers should instead use a full-replacement patch. See https://pr.k8s.io/79391 for an example.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeAddress" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeAddress" "type" [ ]));
           apply = attrsToList;
         };
         "allocatable" = mkOption {
@@ -7016,7 +7034,7 @@ let
         };
         "conditions" = mkOption {
           description = "Conditions is an array of current observed node conditions. More info: https://kubernetes.io/docs/concepts/nodes/node/#condition";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.NodeCondition" "type" [ ]));
           apply = attrsToList;
         };
         "config" = mkOption {
@@ -7041,7 +7059,8 @@ let
         };
         "volumesAttached" = mkOption {
           description = "List of volumes that are attached to the node.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.AttachedVolume")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.AttachedVolume" "name" [ ]));
+          apply = attrsToList;
         };
         "volumesInUse" = mkOption {
           description = "List of attachable volumes in use (mounted) by the node.";
@@ -7382,7 +7401,7 @@ let
         };
         "conditions" = mkOption {
           description = "conditions is the current Condition of persistent volume claim. If underlying persistent volume is being resized then the Condition will be set to 'ResizeStarted'.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PersistentVolumeClaimCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PersistentVolumeClaimCondition" "type" [ ]));
           apply = attrsToList;
         };
         "phase" = mkOption {
@@ -7828,7 +7847,8 @@ let
         };
         "options" = mkOption {
           description = "A list of DNS resolver options. This will be merged with the base options generated from DNSPolicy. Duplicated entries will be removed. Resolution options given in Options will override those that appear in the base DNSPolicy.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.PodDNSConfigOption")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodDNSConfigOption" "name" [ ]));
+          apply = attrsToList;
         };
         "searches" = mkOption {
           description = "A list of DNS search domains for host-name lookup. This will be appended to the base search paths generated from DNSPolicy. Duplicated search paths will be removed.";
@@ -8003,7 +8023,8 @@ let
         };
         "sysctls" = mkOption {
           description = "Sysctls hold a list of namespaced sysctls used for the pod. Pods with unsupported sysctls (by the container runtime) might fail to launch. Note that this field cannot be set when spec.os.name is windows.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.Sysctl")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Sysctl" "name" [ ]));
+          apply = attrsToList;
         };
         "windowsOptions" = mkOption {
           description = "The Windows specific settings applied to all containers. If unspecified, the options within a container's SecurityContext will be used. If set in both SecurityContext and PodSecurityContext, the value specified in SecurityContext takes precedence. Note that this field cannot be set when spec.os.name is linux.";
@@ -8043,7 +8064,7 @@ let
         };
         "containers" = mkOption {
           description = "List of containers belonging to the pod. Containers cannot currently be added or removed. There must be at least one container in a Pod. Cannot be updated.";
-          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name");
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name" [ ]);
           apply = attrsToList;
         };
         "dnsConfig" = mkOption {
@@ -8060,12 +8081,12 @@ let
         };
         "ephemeralContainers" = mkOption {
           description = "List of ephemeral containers run in this pod. Ephemeral containers may be run in an existing pod to perform user-initiated actions such as debugging. This list cannot be specified when creating a pod, and it cannot be modified by updating the pod spec. In order to add an ephemeral container to an existing pod, use the pod's ephemeralcontainers subresource.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.EphemeralContainer" "name" [ ]));
           apply = attrsToList;
         };
         "hostAliases" = mkOption {
           description = "HostAliases is an optional list of hosts and IPs that will be injected into the pod's hosts file if specified. This is only valid for non-hostNetwork pods.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HostAlias" "ip"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.HostAlias" "ip" [ ]));
           apply = attrsToList;
         };
         "hostIPC" = mkOption {
@@ -8090,12 +8111,12 @@ let
         };
         "imagePullSecrets" = mkOption {
           description = "ImagePullSecrets is an optional list of references to secrets in the same namespace to use for pulling any of the images used by this PodSpec. If specified, these secrets will be passed to individual puller implementations for them to use. More info: https://kubernetes.io/docs/concepts/containers/images#specifying-imagepullsecrets-on-a-pod";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name" [ ]));
           apply = attrsToList;
         };
         "initContainers" = mkOption {
           description = "List of initialization containers belonging to the pod. Init containers are executed in order prior to containers being started. If any init container fails, the pod is considered to have failed and is handled according to its restartPolicy. The name for an init container or normal container must be unique among all containers. Init containers may not have Lifecycle actions, Readiness probes, Liveness probes, or Startup probes. The resourceRequirements of an init container are taken into account during scheduling by finding the highest request/limit for each resource type, and then using the max of of that value or the sum of the normal containers. Limits are applied to init containers in a similar fashion. Init containers cannot currently be added or removed. Cannot be updated. More info: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Container" "name" [ ]));
           apply = attrsToList;
         };
         "nodeName" = mkOption {
@@ -8132,7 +8153,7 @@ let
         };
         "resourceClaims" = mkOption {
           description = "ResourceClaims defines which ResourceClaims must be allocated and reserved before the Pod is allowed to start. The resources will be made available to those containers which consume them by name.\n\nThis is an alpha field and requires enabling the DynamicResourceAllocation feature gate.\n\nThis field is immutable.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodResourceClaim" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodResourceClaim" "name" [ ]));
           apply = attrsToList;
         };
         "restartPolicy" = mkOption {
@@ -8149,7 +8170,7 @@ let
         };
         "schedulingGates" = mkOption {
           description = "SchedulingGates is an opaque list of values that if specified will block scheduling the pod. More info:  https://git.k8s.io/enhancements/keps/sig-scheduling/3521-pod-scheduling-readiness.\n\nThis is an alpha-level feature enabled by PodSchedulingReadiness feature gate.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodSchedulingGate" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodSchedulingGate" "name" [ ]));
           apply = attrsToList;
         };
         "securityContext" = mkOption {
@@ -8186,12 +8207,11 @@ let
         };
         "topologySpreadConstraints" = mkOption {
           description = "TopologySpreadConstraints describes how a group of pods ought to spread across topology domains. Scheduler will schedule pods in a way which abides by the constraints. All topologySpreadConstraints are ANDed.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.TopologySpreadConstraint" "topologyKey"));
-          apply = attrsToList;
+          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.TopologySpreadConstraint")));
         };
         "volumes" = mkOption {
           description = "List of volumes that can be mounted by containers belonging to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Volume" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.Volume" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -8244,16 +8264,18 @@ let
       options = {
         "conditions" = mkOption {
           description = "Current service state of pod. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-conditions";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodCondition" "type" [ ]));
           apply = attrsToList;
         };
         "containerStatuses" = mkOption {
           description = "The list has one entry per container in the manifest. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ContainerStatus")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerStatus" "name" [ ]));
+          apply = attrsToList;
         };
         "ephemeralContainerStatuses" = mkOption {
           description = "Status for any ephemeral containers that have run in this pod.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ContainerStatus")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerStatus" "name" [ ]));
+          apply = attrsToList;
         };
         "hostIP" = mkOption {
           description = "IP address of the host to which the pod is assigned. Empty if not yet scheduled.";
@@ -8261,7 +8283,8 @@ let
         };
         "initContainerStatuses" = mkOption {
           description = "The list has one entry per init container in the manifest. The most recent successful init container will have ready = true, the most recently started container will have startTime set. More info: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle#pod-and-container-status";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ContainerStatus")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ContainerStatus" "name" [ ]));
+          apply = attrsToList;
         };
         "message" = mkOption {
           description = "A human readable message indicating details about why the pod is in this condition.";
@@ -8281,7 +8304,7 @@ let
         };
         "podIPs" = mkOption {
           description = "podIPs holds the IP addresses allocated to the pod. If this field is specified, the 0th entry must match the podIP field. Pods may be allocated at most 1 value for each of IPv4 and IPv6. This list is empty if no IPs have been allocated yet.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodIP" "ip"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.PodIP" "ip" [ ]));
           apply = attrsToList;
         };
         "qosClass" = mkOption {
@@ -8809,7 +8832,7 @@ let
         };
         "conditions" = mkOption {
           description = "Represents the latest available observations of a replication controller's current state.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ReplicationControllerCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ReplicationControllerCondition" "type" [ ]));
           apply = attrsToList;
         };
         "fullyLabeledReplicas" = mkOption {
@@ -8991,7 +9014,8 @@ let
       options = {
         "claims" = mkOption {
           description = "Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.\n\nThis is an alpha field and requires enabling the DynamicResourceAllocation feature gate.\n\nThis field is immutable.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.ResourceClaim")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ResourceClaim" "name" [ ]));
+          apply = attrsToList;
         };
         "limits" = mkOption {
           description = "Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/";
@@ -9518,7 +9542,8 @@ let
         };
         "imagePullSecrets" = mkOption {
           description = "ImagePullSecrets is a list of references to secrets in the same namespace to use for pulling any images in pods that reference this ServiceAccount. ImagePullSecrets are distinct from Secrets because Secrets can be mounted in the pod, but ImagePullSecrets are only accessed by the kubelet. More info: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.core.v1.LocalObjectReference")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.LocalObjectReference" "name" [ ]));
+          apply = attrsToList;
         };
         "kind" = mkOption {
           description = "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds";
@@ -9530,7 +9555,7 @@ let
         };
         "secrets" = mkOption {
           description = "Secrets is a list of the secrets in the same namespace that pods running using this ServiceAccount are allowed to use. Pods are only limited to this list if this service account has a \"kubernetes.io/enforce-mountable-secrets\" annotation set to \"true\". This field should not be used to find auto-generated service account token secrets for use outside of pods. Instead, tokens can be requested directly using the TokenRequest API, or service account token secrets can be manually created. More info: https://kubernetes.io/docs/concepts/configuration/secret";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ObjectReference" "name" [ ]));
           apply = attrsToList;
         };
       };
@@ -9724,7 +9749,7 @@ let
         };
         "ports" = mkOption {
           description = "The list of ports that are exposed by this service. More info: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ServicePort" "port"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.core.v1.ServicePort" "name" [ "port" "protocol" ]));
           apply = attrsToList;
         };
         "publishNotReadyAddresses" = mkOption {
@@ -9778,7 +9803,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Current service state";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type" [ ]));
           apply = attrsToList;
         };
         "loadBalancer" = mkOption {
@@ -10522,7 +10547,8 @@ let
       options = {
         "forZones" = mkOption {
           description = "forZones indicates the zone(s) this endpoint should be consumed by to enable topology aware routing.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.discovery.v1.ForZone")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.discovery.v1.ForZone" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -10587,7 +10613,8 @@ let
         };
         "ports" = mkOption {
           description = "ports specifies the list of network ports exposed by each endpoint in this slice. Each port must have a unique name. When ports is empty, it indicates that there are no defined ports. When a port is defined with a nil port value, it indicates \"all ports\". Each slice may include a maximum of 100 ports.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.discovery.v1.EndpointPort")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.discovery.v1.EndpointPort" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -11449,7 +11476,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "`conditions` is a list of the current states of FlowSchema.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.flowcontrol.v1beta3.FlowSchemaCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.flowcontrol.v1beta3.FlowSchemaCondition" "type" [ ]));
           apply = attrsToList;
         };
       };
@@ -11699,7 +11726,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "`conditions` is the current state of \"request-priority\".";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.flowcontrol.v1beta3.PriorityLevelConfigurationCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.flowcontrol.v1beta3.PriorityLevelConfigurationCondition" "type" [ ]));
           apply = attrsToList;
         };
       };
@@ -12432,7 +12459,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Conditions holds an array of metav1.Condition that describe the state of the NetworkPolicy. Current service state";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type" [ ]));
           apply = attrsToList;
         };
       };
@@ -12783,7 +12810,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Conditions contain conditions for PDB. The disruption controller sets the DisruptionAllowed condition. The following are known values for the reason field (additional reasons could be added in the future): - SyncFailed: The controller encountered an error and wasn't able to compute\n              the number of allowed disruptions. Therefore no disruptions are\n              allowed and the status of the condition will be False.\n- InsufficientPods: The number of pods are either at or below the number\n                    required by the PodDisruptionBudget. No disruptions are\n                    allowed and the status of the condition will be False.\n- SufficientPods: There are more pods than required by the PodDisruptionBudget.\n                  The condition will be True, and the number of allowed\n                  disruptions are provided by the disruptionsAllowed property.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.Condition" "type" [ ]));
           apply = attrsToList;
         };
         "currentHealthy" = mkOption {
@@ -12891,7 +12918,8 @@ let
         };
         "subjects" = mkOption {
           description = "Subjects holds references to the objects the role applies to.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.rbac.v1.Subject")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.rbac.v1.Subject" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -13047,7 +13075,8 @@ let
         };
         "subjects" = mkOption {
           description = "Subjects holds references to the objects the role applies to.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.rbac.v1.Subject")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.rbac.v1.Subject" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -13280,7 +13309,8 @@ let
       options = {
         "resourceClaims" = mkOption {
           description = "ResourceClaims describes resource availability for each pod.spec.resourceClaim entry where the corresponding ResourceClaim uses \"WaitForFirstConsumer\" allocation mode.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.resource.v1alpha1.ResourceClaimSchedulingStatus")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.resource.v1alpha1.ResourceClaimSchedulingStatus" "name" [ "name" ]));
+          apply = attrsToList;
         };
       };
 
@@ -13464,7 +13494,8 @@ let
         };
         "reservedFor" = mkOption {
           description = "ReservedFor indicates which entities are currently allowed to use the claim. A Pod which references a ResourceClaim which is not reserved for that Pod will not be started.\n\nThere can be at most 32 such reservations. This may get increased in the future, but not reduced.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.api.resource.v1alpha1.ResourceClaimConsumerReference")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.resource.v1alpha1.ResourceClaimConsumerReference" "name" [ ]));
+          apply = attrsToList;
         };
       };
 
@@ -13922,7 +13953,7 @@ let
       options = {
         "drivers" = mkOption {
           description = "drivers is a list of information of all CSI Drivers existing on a node. If all drivers in the list are uninstalled, this can become empty.";
-          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1.CSINodeDriver" "name");
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.api.storage.v1.CSINodeDriver" "name" [ ]);
           apply = attrsToList;
         };
       };
@@ -14567,7 +14598,8 @@ let
         };
         "versions" = mkOption {
           description = "versions is the list of all API versions of the defined custom resource. Version names are used to compute the order in which served versions are listed in API discovery. If the version string is \"kube-like\", it will sort above non \"kube-like\" version strings, which are ordered lexicographically. \"Kube-like\" versions start with a \"v\", then are followed by a number (the major version), then optionally the string \"alpha\" or \"beta\" and another number (the minor version). These are sorted first by GA > beta > alpha (where GA is a version with no suffix such as beta or alpha), and then by comparing major version, then minor version. An example sorted list of versions: v10, v2, v1, v11beta2, v10beta3, v3beta1, v12alpha1, v11alpha2, foo1, foo10.";
-          type = (types.listOf (submoduleOf "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion"));
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionVersion" "name" [ ]);
+          apply = attrsToList;
         };
       };
 
@@ -14608,7 +14640,8 @@ let
       options = {
         "additionalPrinterColumns" = mkOption {
           description = "additionalPrinterColumns specifies additional columns returned in Table output. See https://kubernetes.io/docs/reference/using-api/api-concepts/#receiving-resources-as-tables for details. If no columns are specified, a single column displaying the age of the custom resource is used.";
-          type = (types.nullOr (types.listOf (submoduleOf "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition")));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceColumnDefinition" "name" [ ]));
+          apply = attrsToList;
         };
         "deprecated" = mkOption {
           description = "deprecated indicates this version of the custom resource API is deprecated. When set to true, API requests to this version receive a warning header in the server response. Defaults to false.";
@@ -14907,7 +14940,7 @@ let
         };
         "x-kubernetes-validations" = mkOption {
           description = "x-kubernetes-validations describes a list of validation rules written in the CEL expression language. This field is an alpha-level. Using this field requires the feature gate `CustomResourceValidationExpressions` to be enabled.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule" "rule"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.ValidationRule" "rule" [ ]));
           apply = attrsToList;
         };
       };
@@ -15103,7 +15136,8 @@ let
         };
         "groups" = mkOption {
           description = "groups is a list of APIGroup.";
-          type = (types.listOf (submoduleOf "io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup"));
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.APIGroup" "name" [ ]);
+          apply = attrsToList;
         };
         "kind" = mkOption {
           description = "Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds";
@@ -15190,7 +15224,8 @@ let
         };
         "resources" = mkOption {
           description = "resources contains the name of the resources and if they are namespaced.";
-          type = (types.listOf (submoduleOf "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource"));
+          type = (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource" "name" [ ]);
+          apply = attrsToList;
         };
       };
 
@@ -15495,7 +15530,7 @@ let
         };
         "ownerReferences" = mkOption {
           description = "List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference" "uid"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.apimachinery.pkg.apis.meta.v1.OwnerReference" "uid" [ ]));
           apply = attrsToList;
         };
         "resourceVersion" = mkOption {
@@ -15931,7 +15966,7 @@ let
       options = {
         "conditions" = mkOption {
           description = "Current service state of apiService.";
-          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition" "type"));
+          type = (types.nullOr (coerceAttrsOfSubmodulesToListByKey "io.k8s.kube-aggregator.pkg.apis.apiregistration.v1.APIServiceCondition" "type" [ ]));
           apply = attrsToList;
         };
       };


### PR DESCRIPTION
This change uses the attribute `name` if `x-kubernetes-patch-merge-key` is not the full `x-kubernetes-list-map-keys` to avoid data corruption.

In particular:
- Use `x-kubernetes-patch-merge-key` only if it agrees with `x-kubernetes-list-map-keys`.
- If `x-kubernetes-patch-merge-key` doesn't agree with `x-kubernetes-list-map-keys`, then use the property `name` if it is present. This then matches the expectation where
  ```nix
    template.spec.containers.test = {
      ports.dns-tcp = {
        containerPort = 54;
        protocol = "TCP";
      };
      ports.dns-udp = {
        containerPort = 54;
        protocol = "UDP";
      };
    };
  ```
  gets transformed into
  ```yaml
    ports:
    - containerPort: 54
      name: dns-tcp
      protocol: TCP
    - containerPort: 54
      name: dns-udp
      protocol: UDP
  ```

- If `name` is not specified, this needs the workaround using `__kubenix_list_merge_key_` in `mergeValuesByKey` and `submoduleWithMergeOf` to not change the original definition when specifying submodules as a list. Then
  ```nix
    template.spec.containers.test = {
      ports = [
        { containerPort = 53;
          protocol = "TCP";
        }
        { containerPort = 53;
          protocol = "UDP";
        }
      ];
    };
  ```
  gets transformed into
  ```yaml
    ports:
    - containerPort: 53
      protocol: TCP
    - containerPort: 53
      protocol: UDP
  ```

- As of kubernetes 1.26, this affects `ContainerPort`, `TopologySpreadConstraint`, and `ServicePort` where `x-kubernetes-patch-merge-key` is not equal to `x-kubernetes-list-map-keys`.

- What doesn't work anymore is to do
  ```nix
   template.spec.containers.test = {
     ports."55" = {};
   };
  ```
  which previously *would* have been transformed into
  ```yaml
    ports:
    - containerPort: 55
  ```
  This is because in order to not discard ports with the same port number, but differing protocol, both would need to be encoded into the attribute name. And because I couldn't find a nice way to make this work, I chose to go with `name` as the merge key instead.

closes hall/kubenix#13