### PR TITLE
add release process and cut version 0.1.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,16 +10,34 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2.4.0
-    - uses: cachix/install-nix-action@v16
-      with:
-        install_url: https://github.com/numtide/nix-unstable-installer/releases/download/nix-2.8.0pre20220311_d532269/install
-        extra_nix_config: |
-          experimental-features = nix-command flakes
-          allow-import-from-derivation = true
+      - name: checkout repo
+        uses: actions/checkout@v3
+  
+      - name: install nix
+        uses: cachix/install-nix-action@v20
 
-    - name: Run Nix Flake Check
-      run: nix -Lv flake check
+      - name: configure cache
+        uses: DeterminateSystems/magic-nix-cache-action@v1
+  
+      - name: check flake
+        run: nix -Lv flake check
+  
+      - name: check nix parsing
+        run: nix -Lv develop -c evalnix
 
-    - name: Check Nix parsing
-      run: nix -Lv develop -c evalnix
+      - name: get latest tag
+        id: latest
+        uses: actions-ecosystem/action-get-latest-tag@v1
+
+      - name: parse changelog
+        id: changelog
+        uses: coditory/changelog-parser@v1
+
+      - name: create release
+        id: release
+        uses: softprops/action-gh-release@v1
+        if: github.ref == 'refs/heads/main' && steps.changelog.outputs.version != steps.latest.outputs.tag
+        with:
+          files: ${{ steps.package.outputs.path }}
+          body: ${{ steps.changelog.outputs.description }}
+          tag_name: ${{ steps.changelog.outputs.version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2023-07-06
+
+### Added
+
+- initial tagged release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,11 @@ Do try to format the repo with [treefmt](https://github.com/numtide/treefmt) bef
 
     nix fmt
 
+## Releases
+
+User-facing changes should be reflected in [`CHANGELOG.md`](./CHANGELOG.md).
+When a new entry is added to the default branch, a new release will automatically be tagged.
+
 ## Kubernetes versions
 
 To support a new Kubernetes version:
@@ -31,7 +36,7 @@ To support a new Kubernetes version:
   }
   ```
 
-- Build and copy the updated specs to [`modules/generated/`](./modules/generated/) with
+- Build the updated specs to [`modules/generated/`](./modules/generated/) with
 
       nix run '.#generate'
 


### PR DESCRIPTION
Adding CI steps to tag releases following CHANGELOG entries to reduce unknowns and provide an easy way to communicate relevant changes.