### PR TITLE
Fix: fix error when containerPort misses protocol

### DIFF
--- a/modules/generated/v1.19.nix
+++ b/modules/generated/v1.19.nix
@@ -79,9 +79,16 @@ let
           # generate merge key for list elements if it's not present
             "__kubenix_list_merge_key_" + (concatStringsSep "" (map
               (key:
-                if isAttrs value.${key}
-                then toString value.${key}.content
-                else (toString value.${key})
+                # set key to default value if unset.
+                let
+                  value' =
+                    if (!(value ? key) && key == "protocol")
+                    then value // { protocol = "TCP"; }
+                    else value;
+                in
+                if isAttrs value'.${key}
+                then toString value'.${key}.content
+                else (toString value'.${key})
               )
               listMergeKeys))
         )

--- a/modules/generated/v1.20.nix
+++ b/modules/generated/v1.20.nix
@@ -79,9 +79,16 @@ let
           # generate merge key for list elements if it's not present
             "__kubenix_list_merge_key_" + (concatStringsSep "" (map
               (key:
-                if isAttrs value.${key}
-                then toString value.${key}.content
-                else (toString value.${key})
+                # set key to default value if unset.
+                let
+                  value' =
+                    if (!(value ? key) && key == "protocol")
+                    then value // { protocol = "TCP"; }
+                    else value;
+                in
+                if isAttrs value'.${key}
+                then toString value'.${key}.content
+                else (toString value'.${key})
               )
               listMergeKeys))
         )

--- a/modules/generated/v1.21.nix
+++ b/modules/generated/v1.21.nix
@@ -79,9 +79,16 @@ let
           # generate merge key for list elements if it's not present
             "__kubenix_list_merge_key_" + (concatStringsSep "" (map
               (key:
-                if isAttrs value.${key}
-                then toString value.${key}.content
-                else (toString value.${key})
+                # set key to default value if unset.
+                let
+                  value' =
+                    if (!(value ? key) && key == "protocol")
+                    then value // { protocol = "TCP"; }
+                    else value;
+                in
+                if isAttrs value'.${key}
+                then toString value'.${key}.content
+                else (toString value'.${key})
               )
               listMergeKeys))
         )

--- a/modules/generated/v1.22.nix
+++ b/modules/generated/v1.22.nix
@@ -79,9 +79,16 @@ let
           # generate merge key for list elements if it's not present
             "__kubenix_list_merge_key_" + (concatStringsSep "" (map
               (key:
-                if isAttrs value.${key}
-                then toString value.${key}.content
-                else (toString value.${key})
+                # set key to default value if unset.
+                let
+                  value' =
+                    if (!(value ? key) && key == "protocol")
+                    then value // { protocol = "TCP"; }
+                    else value;
+                in
+                if isAttrs value'.${key}
+                then toString value'.${key}.content
+                else (toString value'.${key})
               )
               listMergeKeys))
         )

--- a/modules/generated/v1.23.nix
+++ b/modules/generated/v1.23.nix
@@ -79,9 +79,16 @@ let
           # generate merge key for list elements if it's not present
             "__kubenix_list_merge_key_" + (concatStringsSep "" (map
               (key:
-                if isAttrs value.${key}
-                then toString value.${key}.content
-                else (toString value.${key})
+                # set key to default value if unset.
+                let
+                  value' =
+                    if (!(value ? key) && key == "protocol")
+                    then value // { protocol = "TCP"; }
+                    else value;
+                in
+                if isAttrs value'.${key}
+                then toString value'.${key}.content
+                else (toString value'.${key})
               )
               listMergeKeys))
         )

--- a/modules/generated/v1.24.nix
+++ b/modules/generated/v1.24.nix
@@ -79,9 +79,16 @@ let
           # generate merge key for list elements if it's not present
             "__kubenix_list_merge_key_" + (concatStringsSep "" (map
               (key:
-                if isAttrs value.${key}
-                then toString value.${key}.content
-                else (toString value.${key})
+                # set key to default value if unset.
+                let
+                  value' =
+                    if (!(value ? key) && key == "protocol")
+                    then value // { protocol = "TCP"; }
+                    else value;
+                in
+                if isAttrs value'.${key}
+                then toString value'.${key}.content
+                else (toString value'.${key})
               )
               listMergeKeys))
         )

--- a/modules/generated/v1.25.nix
+++ b/modules/generated/v1.25.nix
@@ -79,9 +79,16 @@ let
           # generate merge key for list elements if it's not present
             "__kubenix_list_merge_key_" + (concatStringsSep "" (map
               (key:
-                if isAttrs value.${key}
-                then toString value.${key}.content
-                else (toString value.${key})
+                # set key to default value if unset.
+                let
+                  value' =
+                    if (!(value ? key) && key == "protocol")
+                    then value // { protocol = "TCP"; }
+                    else value;
+                in
+                if isAttrs value'.${key}
+                then toString value'.${key}.content
+                else (toString value'.${key})
               )
               listMergeKeys))
         )

--- a/modules/generated/v1.26.nix
+++ b/modules/generated/v1.26.nix
@@ -79,9 +79,16 @@ let
           # generate merge key for list elements if it's not present
             "__kubenix_list_merge_key_" + (concatStringsSep "" (map
               (key:
-                if isAttrs value.${key}
-                then toString value.${key}.content
-                else (toString value.${key})
+                # set key to default value if unset.
+                let
+                  value' =
+                    if (!(value ? key) && key == "protocol")
+                    then value // { protocol = "TCP"; }
+                    else value;
+                in
+                if isAttrs value'.${key}
+                then toString value'.${key}.content
+                else (toString value'.${key})
               )
               listMergeKeys))
         )

--- a/modules/generated/v1.27.nix
+++ b/modules/generated/v1.27.nix
@@ -79,9 +79,16 @@ let
           # generate merge key for list elements if it's not present
             "__kubenix_list_merge_key_" + (concatStringsSep "" (map
               (key:
-                if isAttrs value.${key}
-                then toString value.${key}.content
-                else (toString value.${key})
+                # set key to default value if unset.
+                let
+                  value' =
+                    if (!(value ? key) && key == "protocol")
+                    then value // { protocol = "TCP"; }
+                    else value;
+                in
+                if isAttrs value'.${key}
+                then toString value'.${key}.content
+                else (toString value'.${key})
               )
               listMergeKeys))
         )

--- a/pkgs/generators/k8s/default.nix
+++ b/pkgs/generators/k8s/default.nix
@@ -399,9 +399,14 @@ with lib; let
             else
               # generate merge key for list elements if it's not present
               "__kubenix_list_merge_key_" + (concatStringsSep "" (map (key:
-                if isAttrs value.''${key}
-                then toString value.''${key}.content
-                else (toString value.''${key})
+	        # set key to default value if unset.
+		let
+		  value' = if (!(value ? key) && key == "protocol")
+		    then value // {protocol = "TCP";}
+		    else value;
+		in if isAttrs value'.''${key}
+                  then toString value'.''${key}.content
+                  else (toString value'.''${key})
               ) listMergeKeys))
           ) (value // { _priority = i; }))
         values);


### PR DESCRIPTION
Using helm chart with ports, without protocol specified (which default to TCP), cause error during https://github.com/hall/kubenix/blob/08740f5f557adf9368fc8388485965935cd241e2/pkgs/generators/k8s/default.nix#L391 evaluation.

This hack use TCP as a default when protocol key is not defined.

I think a cleaner way could be to give default to option, based on k8s default options.