### PR TITLE
Optional functionality for injecting hashed names

### DIFF
--- a/lib/k8s/default.nix
+++ b/lib/k8s/default.nix
@@ -62,6 +62,23 @@ with lib; rec {
       } // labels;
     };
 
+  # Returns "<name>-<hash(data)>"
+  mkNameHash = { name, data, length ? 10 }:
+    "${name}-${builtins.substring 0 length (builtins.hashString "sha1" (builtins.toJSON data))}";
+
+  # Returns the same resources with addition of injected (or overwritten) metadata.name with hashed data
+  # name of the resource in Nix does not change for reference reasons
+  # useful for the ConfigMap and Secret resources
+  injectHashedNames = attrs:
+    lib.mapAttrs
+      (name: o:
+        recursiveUpdate o {
+          metadata.name = mkNameHash { inherit name; data = o.data; };
+        }
+      )
+      attrs;
+
+
   inherit (lib) toBase64;
   inherit (lib) octalToDecimal;
 }


### PR DESCRIPTION
The purpose of injecting hashed names for ConfigMap and Secret resources is that the pods restart if only mentioned resources are updated.

Example: https://github.com/matejc/kubenix-examples/blob/20c6b83ee4da7d1a320f37f0cae2c13ee2d65c88/simple/module.nix
Usage:
```
kubernetes.enableHashedNames = true;  # by default is false
```
And then to get the correct name from injected `metadata.name`:
```
  volumes = {
    config.configMap.name = config.kubernetes.resources.configMaps.nginx-config.metadata.name;
    static.configMap.name = config.kubernetes.resources.configMaps.nginx-static.metadata.name;
  };
```
I was thinking how to make this part also seamless, but I guess there are a lot of edge cases to cover for now.