### PR TITLE
helm: add support for `--api-versions`

### DIFF
--- a/lib/helm/chart2json.nix
+++ b/lib/helm/chart2json.nix
@@ -15,12 +15,15 @@ with lib;
 , includeCRDs ? false
   # whether to include hooks
 , noHooks ? false
+  # Kubernetes api versions used for Capabilities.APIVersions (--api-versions)
+, apiVersions ? null
 }:
 let
   valuesJsonFile = builtins.toFile "${name}-values.json" (builtins.toJSON values);
   # The `helm template` and YAML -> JSON steps are separate `runCommand` derivations for easier debuggability
   resourcesYaml = runCommand "${name}.yaml" { nativeBuildInputs = [ kubernetes-helm ]; } ''
     helm template "${name}" \
+        ${optionalString (apiVersions != null && apiVersions != []) "--api-versions ${lib.strings.concatStringsSep "," apiVersions}"} \
         ${optionalString (kubeVersion != null) "--kube-version ${kubeVersion}"} \
         ${optionalString (namespace != null) "--namespace ${namespace}"} \
         ${optionalString (values != {}) "-f ${valuesJsonFile}"} \

--- a/modules/helm.nix
+++ b/modules/helm.nix
@@ -99,6 +99,17 @@ in
             default = false;
           };
 
+          apiVersions = mkOption {
+            description = ''
+              Inform Helm about which CRDs are available in the cluster (`--api-versions` option).
+              This is useful for charts which contain `.Capabilities.APIVersions.Has` checks.
+              If you use `kubernetes.customTypes` to make kubenix aware of CRDs, it will include those as well by default. 
+            '';
+            type = types.listOf types.str;
+            default = builtins.map (customType: "${customType.group}/${customType.version}")
+              (builtins.attrValues globalConfig.kubernetes.customTypes);
+          };
+
           objects = mkOption {
             description = "Generated kubernetes objects";
             type = types.listOf types.attrs;
@@ -111,7 +122,7 @@ in
         }];
 
         config.objects = importJSON (helm.chart2json {
-          inherit (config) chart name namespace values kubeVersion includeCRDs noHooks;
+          inherit (config) chart name namespace values kubeVersion includeCRDs noHooks apiVersions;
         });
       }));
       default = { };


### PR DESCRIPTION
I think including the option in `chart2json` and the helm module shouldn't cause any issues.

The only thing I am unsure about is whether `builtins.map (customType: "${customType.group}/${customType.version}")
              (builtins.attrValues globalConfig.kubernetes.customTypes)` is a good default value or whether some users will run into e.g. infinite recursion using that.

For me it worked fine though. I fetch CRDs using helm and put them into `kubernetes.customResources` using IFD.