### PR TITLE
Fix default of `helm.releases.<>.apiVersions`

### DIFF
--- a/modules/helm.nix
+++ b/modules/helm.nix
@@ -106,7 +106,12 @@ in
               If you use `kubernetes.customTypes` to make kubenix aware of CRDs, it will include those as well by default. 
             '';
             type = types.listOf types.str;
-            default = builtins.map (customType: "${customType.group}/${customType.version}")
+            default = builtins.concatMap
+              (customType:
+                [
+                  "${customType.group}/${customType.version}"
+                  "${customType.group}/${customType.version}/${customType.kind}"
+                ])
               (builtins.attrValues globalConfig.kubernetes.customTypes);
           };
 


### PR DESCRIPTION
The previous value included only the `<group>.<version>`, e.g. `monitoring.coreos.com/v1`.

But Helm charts actually also check for e.g. `monitoring.coreos.com/v1/ServiceMonitor`. For this reason we need both.