### PR TITLE
fix ConfigMap data with leading underscore (#44)

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -21,6 +21,7 @@ let
             ./k8s/defaults.nix
             ./k8s/order.nix
             ./k8s/submodule.nix
+            ./k8s/configmap.nix
             # TODO: `importYaml` uses IFD which fails during `nix flake check` as it evaluates
             # for all systems, not only the current one: https://github.com/hall/kubenix/issues/12
             # ./k8s/imports.nix

--- a/tests/k8s/configmap.nix
+++ b/tests/k8s/configmap.nix
@@ -1,0 +1,20 @@
+{ config, kubenix, ... }:
+let
+  configMapData = (builtins.head config.kubernetes.objects).data;
+in
+{
+  imports = [ kubenix.modules.test kubenix.modules.k8s ];
+
+  test = {
+    name = "k8s-simple";
+    description = "Test that ConfigMap data keys can have a leading underscore (https://github.com/hall/kubenix/issues/44)";
+    assertions = [
+      {
+        message = "leading underscore in ConfigMap key should be preserved";
+        assertion = configMapData == { _FOO = "_bar"; };
+      }
+    ];
+  };
+
+  kubernetes.resources.configMaps.foo.data._FOO = "_bar";
+}


### PR DESCRIPTION
I tried doing the least amount of changes to fix keys with leading underscore in ConfigMap data.