### PR TITLE
fix: Remove unused `inherit` that break with nix 2.21

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,6 @@
 
       packages = eachSystem (pkgs: {
         default = pkgs.callPackage ./pkgs/kubenix.nix {
-          inherit (self.packages.${system});
           evalModules = self.evalModules.${pkgs.system};
         };
         docs = import ./docs {


### PR DESCRIPTION
With latests nix (2.21) we have an error about undefined variable (even when not used)

```
       error: undefined variable 'system'
       at /nix/store/dnldnw2fvdx6x2vhhxh0kxkm67g3l4sx-source/flake.nix:62:36:
           61|         default = pkgs.callPackage ./pkgs/kubenix.nix {
           62|           inherit (self.packages.${system});
             |                                    ^
           63|           evalModules = self.evalModules.${pkgs.system};
```

It seems that this line was useless (inheriting nothing), removing it fixed the issue