### PR TITLE
Package Kubenix script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] - 2024-05-05
+
+### Breaking
+
+- removed generated Kubernetes manifest file (`manifest.json`) from default flake package
+
+  See the [documentation](https://kubenix.org/#usage) how to access the generated Kubernetes manifest file
 
 ### Added
 
@@ -14,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - removed local `kubectl` and `kubernetes` packages in lieu of those from nixpkgs
+- pin Bash version of Kubenix CLI script
 
 ## [0.2.0] - 2023-07-07
 

--- a/pkgs/kubenix.nix
+++ b/pkgs/kubenix.nix
@@ -2,8 +2,11 @@
 , vals
 , colordiff
 , evalModules
-, runCommand
 , writeShellScript
+, writeScriptBin
+, makeWrapper
+, symlinkJoin
+, lib
 , module ? { }
 , specialArgs ? { }
 }:
@@ -11,85 +14,31 @@ let
   kubernetes = (evalModules {
     inherit module specialArgs;
   }).config.kubernetes or { };
-in
-runCommand "kubenix"
-{
-  kubeconfig = kubernetes.kubeconfig or "";
+
+  kubeconfig = "/home/pim/.kube/config"; # kubernetes.kubeconfig or "";
   result = kubernetes.result or "";
 
   # kubectl does some parsing which removes the -I flag so
   # as workaround, we write to a script and call that
   # https://github.com/kubernetes/kubernetes/pull/108199#issuecomment-1058405404
   diff = writeShellScript "kubenix-diff" ''
-    ${colordiff}/bin/colordiff --nobanner -N -u -I ' kubenix/hash: ' -I ' generation: ' $@
+    ${lib.getExe colordiff} --nobanner -N -u -I ' kubenix/hash: ' -I ' generation: ' $@
   '';
-} ''
-  set -euo pipefail
-  mkdir -p $out/bin
 
-  # write the manifests for use with `nix build`
-  ln -s $result $out/manifest.json
-
-  # create a script for `nix run`
-  cat <<EOF> $out/bin/kubenix
-    set -uo pipefail
-
-    export KUBECONFIG=$kubeconfig
-    export KUBECTL_EXTERNAL_DIFF=$diff
-
-    function _help() {
-      echo "
-      kubenix - Kubernetes management with Nix
-
-      commands:
-        ""          - run diff, prompt for confirmation, then apply
-        apply       - create resources in target cluster
-        diff        - show a diff between configured and live resources
-        render      - print resource manifests to stdout
-
-      options:
-        -h --help   - show this menu
-      "
-    }
-
-    function _kubectl() {
-      ${vals}/bin/vals eval -fail-on-missing-key-in-map < $result | ${kubectl}/bin/kubectl \$@
-    }
-
-    # if no args given, add empty string
-    [ \$# -eq 0 ] && set -- ""
-
-    # parse arguments
-    while test \$# -gt 0; do
-      case "\$1" in
-
-        -h|--help)
-          _help
-        exit 0;;
-
-        "")
-          _kubectl diff -f - --prune
-          if [[ "\$?" -eq 1 ]]; then
-            read -p 'apply? [y/N]: ' response
-            [[ \$response == "y" ]] && _kubectl apply -f - --prune --all
-          fi
-         shift;;
-
-        render)
-          ${vals}/bin/vals eval < $result
-        shift;;
-
-        apply|diff)
-          _kubectl \$@ -f - --prune
-        shift;;
-
-        *)
-          _kubectl \$@
-        shift;;
-
-      esac
-    done
-
-  EOF
-  chmod +x $out/bin/kubenix
-''
+  script = (writeScriptBin "kubenix" (builtins.readFile ./kubenix.sh)).overrideAttrs (old: {
+    buildCommand = "${old.buildCommand}\npatchShebangs $out";
+  });
+in
+symlinkJoin {
+  name = "kubenix";
+  paths = [ script vals kubectl ];
+  buildInputs = [ makeWrapper ];
+  postBuild = ''
+    export DIFF="${diff}"
+    wrapProgram $out/bin/kubenix \
+      --set PATH "$out/bin" \
+      --set KUBECONFIG "${kubeconfig}" \
+      --set KUBECTL_EXTERNAL_DIFF "''${DIFF}" \
+      --set MANIFEST "${result}"
+  '';
+}

--- a/pkgs/kubenix.nix
+++ b/pkgs/kubenix.nix
@@ -15,7 +15,7 @@ let
     inherit module specialArgs;
   }).config.kubernetes or { };
 
-  kubeconfig = "/home/pim/.kube/config"; # kubernetes.kubeconfig or "";
+  kubeconfig = kubernetes.kubeconfig or "";
   result = kubernetes.result or "";
 
   # kubectl does some parsing which removes the -I flag so

--- a/pkgs/kubenix.nix
+++ b/pkgs/kubenix.nix
@@ -33,6 +33,8 @@ symlinkJoin {
   name = "kubenix";
   paths = [ script vals kubectl ];
   buildInputs = [ makeWrapper ];
+  passthru.manifest = result;
+
   postBuild = ''
     export DIFF="${diff}"
     wrapProgram $out/bin/kubenix \

--- a/pkgs/kubenix.sh
+++ b/pkgs/kubenix.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+function _help() {
+  echo "
+  kubenix - Kubernetes management with Nix
+
+  commands:
+    ""          - run diff, prompt for confirmation, then apply
+    apply       - create resources in target cluster
+    diff        - show a diff between configured and live resources
+    render      - print resource manifests to stdout
+
+  options:
+    -h --help   - show this menu
+  "
+}
+
+function _kubectl() {
+  vals eval -fail-on-missing-key-in-map <$MANIFEST | kubectl $@
+}
+
+# if no args given, add empty string
+[ $# -eq 0 ] && set -- ""
+
+# parse arguments
+while test $# -gt 0; do
+  case "$1" in
+
+  -h | --help)
+    _help
+    exit 0
+    ;;
+
+  "")
+    _kubectl diff -f - --prune
+    if [[ $? -eq 1 ]]; then
+      read -p 'apply? [y/N]: ' response
+      [[ $response == "y" ]] && _kubectl apply -f - --prune --all
+    fi
+    shift
+    ;;
+
+  render)
+    vals eval <$MANIFEST
+    shift
+    ;;
+
+  apply | diff)
+    _kubectl $@ -f - --prune
+    shift
+    ;;
+
+  *)
+    _kubectl $@
+    shift
+    ;;
+
+  esac
+done


### PR DESCRIPTION
As suggested in https://github.com/hall/kubenix/pull/60, I used `writeScriptBin` and some other helpers to package the Kubenix script. I extracted the Bash script itself and put it in its own file which  makes it easier to maintain. Using `wrapProgram`, I set the environmental variables that were before set by string substitution.

closes #59 