### PR TITLE
Fix Bash expansion in kubeconfig path of CLI script

### DIFF
--- a/pkgs/kubenix.nix
+++ b/pkgs/kubenix.nix
@@ -36,11 +36,10 @@ symlinkJoin {
   passthru.manifest = result;
 
   postBuild = ''
-    export DIFF="${diff}"
     wrapProgram $out/bin/kubenix \
       --set PATH "$out/bin" \
-      --set KUBECONFIG "${kubeconfig}" \
-      --set KUBECTL_EXTERNAL_DIFF "''${DIFF}" \
-      --set MANIFEST "${result}"
+      --run 'export KUBECONFIG=${kubeconfig}' \
+      --set KUBECTL_EXTERNAL_DIFF '${diff}' \
+      --set MANIFEST '${result}'
   '';
 }

--- a/pkgs/kubenix.nix
+++ b/pkgs/kubenix.nix
@@ -38,7 +38,7 @@ symlinkJoin {
   postBuild = ''
     wrapProgram $out/bin/kubenix \
       --set PATH "$out/bin" \
-      --run 'export KUBECONFIG=${kubeconfig}' \
+      --run 'export KUBECONFIG=''${KUBECONFIG:-${kubeconfig}}' \
       --set KUBECTL_EXTERNAL_DIFF '${diff}' \
       --set MANIFEST '${result}'
   '';


### PR DESCRIPTION
Previous change had a regression where `$HOME` in `kubernetes.kubeconfig` would be expanded at build-time.
This is because `--set KUBECONFIG "${kubeconfig}"` (where `kubeconfig = "$HOME/.kube/config"`) would evaluate to `--set KUBECONFIG "/home/homeless-shelter/.kube/config"` at build-time.

We also cannot do `--set KUBECONFIG '${kubeconfig}'` because `wrapProgram` renders this as `export KUBECONFIG='$HOME/.kube/config'`.
Note the single quotes, which prevents expansion of `$HOME`.

A solution here is to avoid using `--set` altogether and use `--run` with any quotes instead, which allows to expand `~` as well.