### PR TITLE
Suffix PATH on kubenix script

### DIFF
--- a/pkgs/kubenix.nix
+++ b/pkgs/kubenix.nix
@@ -37,7 +37,7 @@ symlinkJoin {
 
   postBuild = ''
     wrapProgram $out/bin/kubenix \
-      --set PATH "$out/bin" \
+      --suffix PATH : "$out/bin" \
       --run 'export KUBECONFIG=''${KUBECONFIG:-${toString kubeconfig}}' \
       --set KUBECTL_EXTERNAL_DIFF '${diff}' \
       --set MANIFEST '${result}'


### PR DESCRIPTION
Fixes #66

Setting the `PATH` to `$out/bin` is causing programs from the original `PATH` (such as `gpg`) to be inaccessible to `vals` - causing decryption of sops secrets with `gpg` to fail.