### PR TITLE
Fix README typo rev -> ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Or, if you're not using flakes, a `default.nix` file (build with `nix-build`):
 ```nix
 { kubenix ? import (builtins.fetchGit {
   url = "https://github.com/hall/kubenix.git";
-  rev = "main";
+  ref = "main";
 }) }:
 (kubenix.evalModules.x86_64-linux {
   module = { kubenix, ... }: {


### PR DESCRIPTION
Just stumbled across this typo following the README. `ref` was mixed up with `rev` in the non-flakes example.

nix-build failed with:
```
error: hash 'main' has wrong length for hash algorithm 'sha1'
```