### PR TITLE
fix: bump all action versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
   
       - name: install nix
-        uses: cachix/install-nix-action@v20
+        uses: cachix/install-nix-action@v31
 
       - name: configure cache
-        uses: DeterminateSystems/magic-nix-cache-action@v1
+        uses: DeterminateSystems/magic-nix-cache-action@main
   
       - name: check flake
         run: nix -Lv flake check
@@ -32,9 +32,10 @@ jobs:
 
       - name: create release
         id: release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         if: github.ref == 'refs/heads/main' && steps.changelog.outputs.version != steps.latest.outputs.tag
         with:
           files: ${{ steps.package.outputs.path }}
           body: ${{ steps.changelog.outputs.description }}
           tag_name: ${{ steps.changelog.outputs.version }}
+

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,30 +16,31 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: true
           fetch-depth: 0
 
       - name: install nix
-        uses: cachix/install-nix-action@v20
+        uses: cachix/install-nix-action@v31
 
       - name: configure cache
-        uses: DeterminateSystems/magic-nix-cache-action@v1
+        uses: DeterminateSystems/magic-nix-cache-action@main
 
       - name: build
         run: nix run '.#docs' -- --minify
 
       - name: upload
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           path: './docs/public'
 
       - name: deploy
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4
 
 permissions:
   contents: read
   pages: write
   id-token: write
+


### PR DESCRIPTION
Notably, the `upload-artifacts` action was using a deprecated version. https://github.com/hall/kubenix/actions/runs/15981875825/job/45077875345#step:1:46