### PR TITLE
yq-go instead of yq to improve the formatting of the resulting YAML

### DIFF
--- a/lib/upstreamables.nix
+++ b/lib/upstreamables.nix
@@ -8,14 +8,14 @@ with lib; let
 
     toYAML = config:
       builtins.readFile (pkgs.runCommand "to-yaml" { } ''
-        ${pkgs.yq}/bin/yq -y . ${pkgs.writeText "to-json" (builtins.toJSON config)}  > $out
+        ${pkgs.yq-go}/bin/yq --output-format=yaml . ${pkgs.writeText "to-json" (builtins.toJSON config)}  > $out
       '');
 
     toMultiDocumentYaml = name: documents:
       pkgs.runCommand name { }
         (concatMapStringsSep "\necho --- >> $out\n"
           (
-            d: "${pkgs.yq}/bin/yq -y . ${pkgs.writeText "to-json" (builtins.toJSON d)} >> $out"
+            d: "${pkgs.yq-go}/bin/yq --output-format=yaml . ${pkgs.writeText "to-json" (builtins.toJSON d)} >> $out"
           )
           documents);
 


### PR DESCRIPTION
_Here I will use the names of the **yq** and **yq-go** packages, that is, in the form in which they are called in **nixpkg**s. I call the **yq** package the [kislyuk/yq](https://github.com/kislyuk/yq) utility written in **python**, and **yq-go** is a [mikefarah/yq](https://github.com/mikefarah/yq) utility written in **go**._

I usually generate a YAML file using kubenix, so I noticed one drawback in terms of YAML formatting.

[yq](https://github.com/kislyuk/yq) can't **pretty-print** yaml. By "pretty-print" I mean better **formatting line breaks** in yaml. yaml allows you to wrap lines using forward slash characters (`|`) or angle brackets (`>`), but the [yq](https://github.com/kislyuk/yq) package does not do this, and as a result, we get these lines (when we use `''...''` in nix):

```yaml
default.conf: "server {\n  listen 80 default_server;\n  server_name _;\n  default_type\
  \ text/plain;\n  location / {\n    return 200 'Hello from $hostname\\n';\n  }\n\
  }\n"
```

[yq-go](https://github.com/mikefarah/yq), in turn, can format yaml in a readable format by default.:

```yaml
default.conf: |
  server {
    listen 80 default_server;
    server_name _;
    default_type text/plain;
    location / {
      return 200 'Hello from $hostname\n';
    }
  }
```

So, in the commit, I just changed the **command** for the `toYaml` and `toMultiDocumentYaml` functions. I changed **yq** to **yq-go**.

_To be honest, I just wanted to create a feature request **issue**, because I decided to entrust the code change to knowledgeable and more experienced people, but after digging into the code, I noticed that a simple change was required and decided to immediately create (my first anywhere) **pull request**. If I did something wrong, please point it out.🙏_ 

_Anyway, I want to express my gratitude to everyone who had a hand in kubenix - you are creating a very valuable project.❤️_