### PR TITLE
Make helm.fetch respect proxy variables

### DIFF
--- a/lib/helm/fetchhelm.nix
+++ b/lib/helm/fetchhelm.nix
@@ -24,6 +24,8 @@ in
 stdenvNoCC.mkDerivation {
   name = "${cleanName chart}-${ if version == null then "dev" else version }";
 
+  impureEnvVars = lib.fetchers.proxyImpureEnvVars;
+
   buildCommand = ''
     export HOME="$PWD"
     echo "adding helm repo"


### PR DESCRIPTION
Fixes #91 

At the moment, `helm.fetch` does not respect the proxy variables of the Nix-daemon, so that fetching in restricted environments, that require forward proxies, fails. This is in contrast to nixpkgs fetchers, which use `impureEnvVars` to pass the nix-daemon's proxy variables, e.g. see https://github.com/NixOS/nixpkgs/blob/master/pkgs/build-support/fetchgit/default.nix#L187