### PR TITLE
ci: add automated weekly flake input update

### DIFF
--- a/.github/workflows/update-flake.yml
+++ b/.github/workflows/update-flake.yml
@@ -1,0 +1,33 @@
+name: Update Flake Inputs
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Run every Sunday at midnight
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  update-flake:
+    permissions:
+      contents: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+
+      - name: Update flake inputs
+        run: nix flake update
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore: update flake inputs"
+          title: "chore: update flake inputs"
+          body: "Automated update of flake inputs."
+          branch: "update-flake-inputs"
+          base: "main"
+          delete-branch: true


### PR DESCRIPTION
this will create a PR with flake inputs update once a week

@hall for this to work we'll have to allow new PRs to be created from an action
would you be able to do the following in the repo's Setting > Actions > General, as I don't have access? Thanks!

<img width="1387" height="1252" alt="image" src="https://github.com/user-attachments/assets/a9d41970-8645-49a6-a8d0-ea03c4d34212" />
