### PR TITLE
fix: don't assume custom resources have a spec field

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -22,6 +22,7 @@ let
             ./k8s/order.nix
             ./k8s/submodule.nix
             ./k8s/configmap.nix
+            ./k8s/custom-types-switch.nix
             # TODO: `importYaml` uses IFD which fails during `nix flake check` as it evaluates
             # for all systems, not only the current one: https://github.com/hall/kubenix/issues/12
             # ./k8s/imports.nix

--- a/tests/k8s/custom-types-switch.nix
+++ b/tests/k8s/custom-types-switch.nix
@@ -1,0 +1,45 @@
+{ config, lib, kubenix, ... }:
+with lib;
+{
+  imports = with kubenix.modules; [ k8s ];
+
+  test = {
+    name = "customTypesModuleDefinesCRDSpec";
+    description = "Test customTypesModuleDefinesCRDSpec = false";
+    assertions = [{
+      message = "Custom resource should have correct version set";
+      assertion = lib.removeAttrs config.kubernetes.api.resources.flexibleResource.test [ "metadata" ] == {
+        apiVersion = "example.com/v1";
+        kind = "FlexibleResource";
+        spec.foo = "bar";
+        status = "active";
+      };
+    }];
+  };
+
+  kubernetes.customTypesModuleDefinesCRDSpec = false;
+
+  kubernetes.customTypes = [
+    {
+      group = "example.com";
+      version = "v1";
+      kind = "FlexibleResource";
+      attrName = "flexibleResource";
+      module = {
+        options.spec = mkOption {
+          type = types.attrs;
+          default = { };
+        };
+        options.status = mkOption {
+          type = types.str;
+          default = "";
+        };
+      };
+    }
+  ];
+
+  kubernetes.resources.flexibleResource.test = {
+    spec.foo = "bar";
+    status = "active";
+  };
+}


### PR DESCRIPTION
This change introduces a new option `customTypesModuleDefinesCRDSpec` (default: true) to allow users to define the full structure of a custom resource, rather than just the `spec` field.

- Adds `customTypesModuleDefinesCRDSpec` option.
- Refactors `customResourceModuleForType` to conditionally wrap the module in `options.spec` or use it directly.
- Improves type safety by using `types.deferredModule` and removing `types.either`.
- Adds a test case `tests/k8s/custom-types-switch.nix` covering the new functionality.
- Closes #35
- Closes #95

supersedes https://github.com/hall/kubenix/pull/73 (@khaled FYI)
