### PR TITLE
Add documentation and example for Custom Resource Definitions (CRDs)

### DIFF
--- a/docs/content/examples/custom-resources/_index.md
+++ b/docs/content/examples/custom-resources/_index.md
@@ -1,0 +1,39 @@
+---
+title: "Custom Resources"
+linkTitle: "Custom Resources"
+weight: 80
+description: >
+  Defining and using Custom Resource Definitions (CRDs).
+---
+
+The `kubernetes.customTypes` option allows you to register Custom Resource Definitions (CRDs) with Kubenix. This enables type-safe definition of custom resources using Nix options.
+
+## Defining Custom Types
+
+To register a CRD, add an entry to the `kubernetes.customTypes` list. Each entry defines the Group, Version, Kind, and the Nix module that describes the schema of the resource.
+
+## Example
+
+{{< file "module.nix" >}}
+
+## Instantiation
+
+Once a custom type is defined, you can instantiate resources under `kubernetes.resources.<attrName>`. In the example above, we set `attrName = "crontabs"`, so we can define resources under `kubernetes.resources.crontabs`.
+
+The generated JSON output will look something like this:
+
+```json
+{
+  "apiVersion": "stable.example.com/v1",
+  "kind": "CronTab",
+  "metadata": {
+    "name": "my-new-cron-object",
+     ...
+  },
+  "spec": {
+    "cronSpec": "* * * * */5",
+    "image": "my-awesome-cron-image",
+    "replicas": 1
+  }
+}
+```

--- a/docs/content/examples/custom-resources/default.nix
+++ b/docs/content/examples/custom-resources/default.nix
@@ -1,0 +1,9 @@
+{ kubenix ? import ../../../.. }:
+kubenix.evalModules.${builtins.currentSystem} {
+  module = { kubenix, ... }: {
+    imports = [ ./module.nix ];
+
+    kubenix.project = "custom-resources-example";
+    kubernetes.version = "1.24";
+  };
+}

--- a/docs/content/examples/custom-resources/module.nix
+++ b/docs/content/examples/custom-resources/module.nix
@@ -1,0 +1,39 @@
+{ kubenix, config, lib, ... }: {
+  imports = [ kubenix.modules.k8s ];
+
+  # 1. Define the Custom Resource Definition (CRD)
+  # This tells Kubenix about the new resource type so it can generate options for it.
+  kubernetes.customTypes = [{
+    group = "stable.example.com";
+    version = "v1";
+    kind = "CronTab";
+    # The attribute name to use under `kubernetes.resources`
+    attrName = "crontabs";
+    # Define the schema of the custom resource using Nix options
+    module = {
+      options = {
+        cronSpec = lib.mkOption {
+          description = "Cron schedule";
+          type = lib.types.str;
+        };
+        image = lib.mkOption {
+          description = "Image to run";
+          type = lib.types.str;
+        };
+        replicas = lib.mkOption {
+          description = "Number of replicas";
+          type = lib.types.int;
+          default = 1;
+        };
+      };
+    };
+  }];
+
+  # 2. Instantiate the Custom Resource
+  # Now we can use the `crontabs` attribute to define resources.
+  kubernetes.resources.crontabs.my-new-cron-object = {
+    metadata.name = "my-new-cron-object";
+    spec.cronSpec = "* * * * */5";
+    spec.image = "my-awesome-cron-image";
+  };
+}

--- a/docs/content/examples/default.nix
+++ b/docs/content/examples/default.nix
@@ -1,4 +1,5 @@
 {
   deployment = import ./deployment { };
   testing = import ./testing { };
+  custom-resources = import ./custom-resources { };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -75,6 +75,7 @@
         pkgs.lib.attrsets.genAttrs' [
           "namespaces"
           "deployment"
+          "custom-resources"
         ]
           (name: pkgs.lib.nameValuePair
             ("example-" + name)


### PR DESCRIPTION
This adds a new example and documentation page explaining how to define custom resources using `kubernetes.customTypes` and how to instantiate them. The example is also added to `flake.nix` to ensure it is verified during checks.

Closes #94

@sheepforce @DerRockWolf