### PR TITLE
fix(k8s): use generated.items for resultYAML to include hash labels

### DIFF
--- a/modules/k8s.nix
+++ b/modules/k8s.nix
@@ -594,6 +594,6 @@ in
       pkgs.writeText "${config.kubenix.project}-generated.json" (builtins.toJSON cfg.generated);
 
     kubernetes.resultYAML =
-      toMultiDocumentYaml "${config.kubenix.project}-generated.yaml" config.kubernetes.objects;
+      toMultiDocumentYaml "${config.kubenix.project}-generated.yaml" config.kubernetes.generated.items;
   };
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -16,6 +16,8 @@ let
           name = "kubenix-${k8sVersion}";
           tests = [
             ./k8s/simple.nix
+            ./k8s/hash-label.nix
+            ./k8s/no-hash-label.nix
             ./k8s/deployment.nix
             ./k8s/crd.nix # flaky
             ./k8s/defaults.nix

--- a/tests/k8s/hash-label.nix
+++ b/tests/k8s/hash-label.nix
@@ -1,0 +1,29 @@
+{ config, kubenix, lib, ... }:
+let
+  cfg = config.kubernetes;
+
+  # Helper to check if a string contains another string
+  contains = str: substr:
+    builtins.match ".*${substr}.*" str != null;
+
+  # Helper to read the resultYAML file
+  resultYAMLContent = builtins.readFile cfg.resultYAML;
+in
+{
+  imports = [ kubenix.modules.test kubenix.modules.k8s ];
+
+  kubernetes.resources.pods.test-pod = {
+    spec.containers.nginx.image = "nginx";
+  };
+
+  test = {
+    name = "k8s-hash-label";
+    description = "Test checking whether resultYAML contains hash labels";
+    assertions = [
+      {
+        message = "resultYAML should contain kubenix/hash label when addHashLabel is true (default)";
+        assertion = contains resultYAMLContent "kubenix/hash";
+      }
+    ];
+  };
+}

--- a/tests/k8s/no-hash-label.nix
+++ b/tests/k8s/no-hash-label.nix
@@ -1,0 +1,31 @@
+{ config, kubenix, lib, ... }:
+let
+  cfg = config.kubernetes;
+
+  # Helper to check if a string contains another string
+  contains = str: substr:
+    builtins.match ".*${substr}.*" str != null;
+
+  # Helper to read the resultYAML file
+  resultYAMLContent = builtins.readFile cfg.resultYAML;
+in
+{
+  imports = [ kubenix.modules.test kubenix.modules.k8s ];
+
+  kubernetes.resources.pods.test-pod = {
+    spec.containers.nginx.image = "nginx";
+  };
+
+  kubernetes.addHashLabel = false;
+
+  test = {
+    name = "k8s-no-hash-label";
+    description = "Test checking whether resultYAML does NOT contain hash labels when addHashLabel is false";
+    assertions = [
+      {
+        message = "resultYAML should NOT contain kubenix/hash label when addHashLabel is false";
+        assertion = !(contains resultYAMLContent "kubenix/hash");
+      }
+    ];
+  };
+}


### PR DESCRIPTION
This change updates `kubernetes.resultYAML` to use `config.kubernetes.generated.items` instead of `config.kubernetes.objects`.
This ensures that the generated YAML includes all transformations applied during list generation, specifically the `kubenix/hash` label added when `addHashLabel` is true.

Added tests:
- `tests/k8s/hash-label.nix`: Verifies that `resultYAML` contains `kubenix/hash` when `addHashLabel` is true.
- `tests/k8s/no-hash-label.nix`: Verifies that `resultYAML` does not contain `kubenix/hash` when `addHashLabel` is false.

fixes #96 