### PR TITLE
refactor(docker): respect image settings, use vals, customizable registry protocol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,41 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Breaking
+
+- `docker.copyScript` now produces a binary at `$out/bin/kubenix-push-images` instead of a shell script. Use `nix run .#kubenix.config.docker.copyScript` for a more ergonomic experience.
+
+- Registry URL options have been restructured. Instead of `docker.registry.url` and `docker.images.*.registry`, use:
+  - `docker.registry.protocol` (default: `"docker://"`)
+  - `docker.registry.host` (default: `""`)
+  - `docker.images.*.registry.protocol`
+  - `docker.images.*.registry.host`
+
+- `docker.copyScript` now pushes to `docker.images.*.uri` instead of using `imageName` and `imageTag` passthru attributes from the image derivation. This allows dynamic values via `vals` for secrets and runtime variables.
+
+  **Migration:** Import the compatibility module to restore pre-v0.4.0 behavior:
+
+  ```nix
+  imports = [ kubenix.modules.docker-image-from-package ];
+  ```
+
+  This module:
+  - Maps `docker.registry.url` to `docker.registry.host`
+  - Maps `docker.images.*.registry` (string) to `docker.images.*.registry.host`
+  - Forces `name`/`tag` to use derivation's `imageName`/`imageTag`
+
+  You will see deprecation warnings guiding you to migrate.
+
+- If you don't want `vals` expansion when pushing images (e.g., in air-gapped environments), set `docker.useVals = false`.
+
+### Added
+
+- Image registry, name, and tag can now use `vals` syntax for dynamic/secret expansion at runtime.
+
+- Customizable registry protocol (`docker.registry.protocol` and `docker.images.*.registry.protocol`).
+
 ## [0.3.0] - 2024-05-05
 
 ### Breaking

--- a/docs/content/examples/image/default.nix
+++ b/docs/content/examples/image/default.nix
@@ -3,7 +3,7 @@ kubenix.evalModules.${builtins.currentSystem} {
   module = { kubenix, config, pkgs, ... }: {
     imports = with kubenix.modules; [ k8s docker ];
     docker = {
-      registry.url = "docker.somewhere.io";
+      registry.host = "docker.somewhere.io";
       images.example.image = pkgs.callPackage ./image.nix { };
     };
     kubernetes.resources.pods.example.spec.containers = {

--- a/flake.nix
+++ b/flake.nix
@@ -184,6 +184,12 @@
             evalModules = self.evalModules.${pkgs.stdenv.hostPlatform.system};
             images = pkgs.callPackage ./tests/images.nix { };
           };
+          docker-image-from-package = import ./tests/docker/image-from-package.nix {
+            inherit pkgs;
+            inherit (self.nixosModules) kubenix;
+            evalModules = self.evalModules.${pkgs.stdenv.hostPlatform.system};
+            images = pkgs.callPackage ./tests/images.nix { };
+          };
         } // builtins.listToAttrs (builtins.map
           (v: {
             name = "test-k8s-${builtins.replaceStrings ["."] ["_"] v}";

--- a/flake.nix
+++ b/flake.nix
@@ -178,6 +178,12 @@
           label-filtering = pkgs.callPackage ./tests/label-filtering.nix {
             kubenix = self.packages.${pkgs.system}.default;
           };
+          docker-multiple-registries = import ./tests/docker/multiple-registries.nix {
+            inherit pkgs;
+            inherit (self.nixosModules) kubenix;
+            evalModules = self.evalModules.${pkgs.stdenv.hostPlatform.system};
+            images = pkgs.callPackage ./tests/images.nix { };
+          };
         } // builtins.listToAttrs (builtins.map
           (v: {
             name = "test-k8s-${builtins.replaceStrings ["."] ["_"] v}";

--- a/lib/docker/default.nix
+++ b/lib/docker/default.nix
@@ -1,19 +1,42 @@
-{ lib, pkgs }:
-with lib; {
-  copyDockerImages = { images, dest, args ? "" }:
-    pkgs.writeScript "copy-docker-images.sh" (concatMapStrings
-      (image:
-        let
-          prefix = optionalString (image.isExe or false) "${image} | ${pkgs.gzip}/bin/gzip --fast |";
-          src = if image.isExe or false then "/dev/stdin" else image;
-        in
-        ''
-          #!${pkgs.runtimeShell}
-
-          set -e
-
-          echo "copying '${image.imageName}:${image.imageTag}' to '${dest}/${image.imageName}:${image.imageTag}'"
-          ${prefix} ${pkgs.skopeo}/bin/skopeo copy ${args} $@ docker-archive:${src} ${dest}/${image.imageName}:${image.imageTag}
-        '')
-      images);
+{ lib
+, pkgs
+,
+}: {
+  copyDockerImages =
+    { images
+    , args ? ""
+    ,
+    }:
+    pkgs.writeShellApplication {
+      name = "kubenix-push-images";
+      excludeShellChecks = [
+        "SC2005"
+        "SC2016"
+        "SC2089"
+        "SC2090"
+      ];
+      runtimeEnv = {
+        copyOne = ''
+        '';
+      };
+      runtimeInputs = [
+        pkgs.gzip
+        pkgs.skopeo
+        pkgs.vals
+      ];
+      text =
+        lib.concatMapStrings
+          ({ image
+           , uri
+           , prefix ? lib.optionalString (image.isExe or false) "${image} | gzip --fast |"
+           , src ? if image.isExe or false
+             then "/dev/stdin"
+             else image
+           , ...
+           }: ''
+            echo "copying '${image.imageName}:${image.imageTag}' to '$(vals get ${lib.escapeShellArg uri})'"
+            ${prefix} skopeo copy ${args} "$@" docker-archive:${lib.escapeShellArg src} "$(vals get ${lib.escapeShellArg uri})"
+          '')
+          images;
+    };
 }

--- a/lib/docker/default.nix
+++ b/lib/docker/default.nix
@@ -5,6 +5,7 @@
   copyDockerImages =
     { images
     , args ? ""
+    , useVals ? true
     ,
     }:
     pkgs.writeShellApplication {
@@ -12,6 +13,7 @@
       excludeShellChecks = [
         "SC2005"
         "SC2016"
+        "SC2046"
         "SC2089"
         "SC2090"
       ];
@@ -22,8 +24,7 @@
       runtimeInputs = [
         pkgs.gzip
         pkgs.skopeo
-        pkgs.vals
-      ];
+      ] ++ lib.optionals useVals [ pkgs.vals ];
       text =
         lib.concatMapStrings
           ({ image
@@ -33,10 +34,14 @@
              then "/dev/stdin"
              else image
            , ...
-           }: ''
-            echo "copying '${image.imageName}:${image.imageTag}' to '$(vals get ${lib.escapeShellArg uri})'"
-            ${prefix} skopeo copy ${args} "$@" docker-archive:${lib.escapeShellArg src} "$(vals get ${lib.escapeShellArg uri})"
-          '')
+           }:
+            let
+              resolvedUri = if useVals then "$(vals get ${lib.escapeShellArg uri})" else lib.escapeShellArg uri;
+            in
+            ''
+              echo "copying '${image.imageName}:${image.imageTag}' to '${resolvedUri}'"
+              ${prefix} skopeo copy ${args} "$@" docker-archive:${lib.escapeShellArg src} ${resolvedUri}
+            '')
           images;
     };
 }

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -5,6 +5,7 @@
   submodule = ./submodule.nix;
   helm = ./helm.nix;
   docker = ./docker.nix;
+  docker-image-from-package = ./docker-image-from-package.nix;
   testing = ./testing;
   test = ./testing/test-options.nix;
   base = ./base.nix;

--- a/modules/docker-image-from-package.nix
+++ b/modules/docker-image-from-package.nix
@@ -1,0 +1,18 @@
+{ config
+, lib
+, ...
+}:
+let
+  cfg = config.docker;
+in
+{
+  imports = [ ./docker.nix ];
+
+  options.docker.registry.url = lib.mkOption {
+    description = "DEPRECATED: Use docker.registry.host instead";
+    type = lib.types.str;
+    default = "";
+  };
+
+  config.docker.registry.host = lib.mkIf (cfg.registry.url != "") cfg.registry.url;
+}

--- a/modules/docker.nix
+++ b/modules/docker.nix
@@ -1,15 +1,32 @@
 { config, lib, pkgs, docker, ... }:
 with lib; let
   cfg = config.docker;
+  protocols = [
+    "containers-storage:"
+    "dir:"
+    "docker://"
+    "docker-archive:"
+    "docker-daemon:"
+    "oci:"
+    "oci-archive:"
+  ];
 in
 {
   imports = [ ./base.nix ];
 
   options.docker = {
-    registry.url = mkOption {
-      description = "Default registry url where images are published";
-      type = types.str;
-      default = "";
+    registry = {
+      protocol = mkOption {
+        description = "Default registry protocol where images are published";
+        type = types.enum protocols;
+        default = "docker://";
+      };
+
+      host = mkOption {
+        description = "Default registry host where images are published";
+        type = types.str;
+        default = "";
+      };
     };
 
     images = mkOption {
@@ -40,19 +57,38 @@ in
               else "";
           };
 
-          registry = mkOption {
-            description = "Docker registry url where image is published";
-            type = types.str;
-            default = cfg.registry.url;
+          registry = {
+            protocol = mkOption {
+              description = "Default registry protocol where this image is published";
+              type = types.enum protocols;
+              default = cfg.registry.protocol;
+            };
+
+            host = mkOption {
+              description = "Default registry host where this image is published";
+              type = types.str;
+              default = cfg.registry.host;
+            };
           };
 
           path = mkOption {
             description = "Full docker image path";
             type = types.str;
-            default =
-              if config.registry != ""
-              then "${config.registry}/${config.name}:${config.tag}"
-              else "${config.name}:${config.tag}";
+            default = lib.concatStrings [
+              (if config.registry == "" then "" else "${config.registry.host}/")
+              config.name
+              ":"
+              config.tag
+            ];
+          };
+
+          uri = mkOption {
+            description = "Full docker image URI";
+            type = types.str;
+            default = lib.concatStrings [
+              config.registry.protocol
+              config.path
+            ];
           };
         };
       }));
@@ -69,8 +105,7 @@ in
       description = "Image copy script";
       type = types.package;
       default = docker.copyDockerImages {
-        dest = "docker://${cfg.registry.url}";
-        images = cfg.export;
+        images = builtins.attrValues cfg.images;
       };
     };
   };

--- a/modules/docker.nix
+++ b/modules/docker.nix
@@ -75,7 +75,7 @@ in
             description = "Full docker image path";
             type = types.str;
             default = lib.concatStrings [
-              (if config.registry == "" then "" else "${config.registry.host}/")
+              (if config.registry.host == "" then "" else "${config.registry.host}/")
               config.name
               ":"
               config.tag
@@ -101,10 +101,24 @@ in
       default = [ ];
     };
 
+    useVals = mkOption {
+      description = "Whether to use vals for expanding image URIs at runtime in the copy script. Disable for air-gapped environments or when URIs contain no dynamic values.";
+      type = types.bool;
+      default = true;
+    };
+
+    copyScriptArgs = mkOption {
+      description = "Additional arguments to pass to skopeo copy in the copy script";
+      type = types.str;
+      default = "";
+    };
+
     copyScript = mkOption {
       description = "Image copy script";
       type = types.package;
       default = docker.copyDockerImages {
+        inherit (cfg) useVals;
+        args = cfg.copyScriptArgs;
         images = builtins.attrValues cfg.images;
       };
     };
@@ -128,6 +142,6 @@ in
 
     # list of exported docker images
     docker.export = mapAttrsToList (_: i: i.image)
-      (filterAttrs (_: i: i.registry != null) config.docker.images);
+      (filterAttrs (_: i: i.image != null) config.docker.images);
   };
 }

--- a/modules/testing/docker.nix
+++ b/modules/testing/docker.nix
@@ -1,4 +1,8 @@
-{ config, lib, pkgs, ... }:
+{ config
+, lib
+, pkgs
+, ...
+}:
 with lib;
 with import ../../lib/docker { inherit lib pkgs; }; let
   inherit (config) testing;
@@ -9,8 +13,8 @@ with import ../../lib/docker { inherit lib pkgs; }; let
 in
 {
   options.testing.docker = {
-    registryUrl = mkOption {
-      description = "Docker registry url";
+    registryHost = mkOption {
+      description = "Docker registry host";
       type = types.str;
     };
 
@@ -30,15 +34,16 @@ in
 
     copyScript = copyDockerImages {
       inherit (cfg) images;
-      dest = "docker://" + cfg.registryUrl;
     };
   };
 
-  config.testing.common = [{
-    features = [ "docker" ];
-    options = {
-      _file = "testing.docker.registryUrl";
-      docker.registry.url = cfg.registryUrl;
-    };
-  }];
+  config.testing.common = [
+    {
+      features = [ "docker" ];
+      options = {
+        _file = "testing.docker.registryHost";
+        docker.registry.host = cfg.registryHost;
+      };
+    }
+  ];
 }

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -39,7 +39,7 @@ let
           ];
 
           args = { images = pkgs.callPackage ./images.nix { }; };
-          docker.registryUrl = registry;
+          docker.registryHost = registry;
 
           common = [{
             features = [ "k8s" ];

--- a/tests/docker/image-from-package.nix
+++ b/tests/docker/image-from-package.nix
@@ -1,0 +1,71 @@
+{ images
+, evalModules
+, pkgs
+, ...
+}:
+let
+  moduleWithCompat = evalModules {
+    modules = [
+      ({ kubenix, ... }: {
+        imports = [ kubenix.modules.docker-image-from-package ];
+        docker = {
+          registry.url = "old-registry:5000";
+          images.curl1.image = images.curl;
+        };
+      })
+    ];
+  };
+
+  moduleWithoutCompat = evalModules {
+    modules = [
+      ({ kubenix, ... }: {
+        imports = [ kubenix.modules.docker ];
+        docker = {
+          registry.host = "new-registry:5000";
+          images.curl1.image = images.curl;
+        };
+      })
+    ];
+  };
+in
+pkgs.testers.runNixOSTest {
+  name = "docker-image-from-package";
+
+  nodes.client = {
+    environment.systemPackages = [
+      moduleWithCompat.config.docker.copyScript
+      moduleWithoutCompat.config.docker.copyScript
+      pkgs.skopeo
+    ];
+  };
+
+  testScript = ''
+    # Test 1: Verify old registry.url maps to registry.host
+    assert "${moduleWithCompat.config.docker.registry.host}" == "old-registry:5000", \
+      "Expected registry.host to be 'old-registry:5000'"
+
+    # Test 2: Verify name/tag defaults use package values
+    curl1_name = "${moduleWithCompat.config.docker.images.curl1.name}"
+    curl1_tag = "${moduleWithCompat.config.docker.images.curl1.tag}"
+    assert curl1_name == "curl", f"Expected curl1 name to be 'curl', got: {curl1_name}"
+    assert curl1_tag == "latest", f"Expected curl1 tag to be 'latest', got: {curl1_tag}"
+
+    # Test 3: Verify path is correctly constructed
+    curl1_path = "${moduleWithCompat.config.docker.images.curl1.path}"
+    assert curl1_path == "old-registry:5000/curl:latest", \
+      f"Expected curl1 path to be 'old-registry:5000/curl:latest', got: {curl1_path}"
+
+    # Test 4: Verify uri is correctly constructed
+    curl1_uri = "${moduleWithCompat.config.docker.images.curl1.uri}"
+    assert curl1_uri == "docker://old-registry:5000/curl:latest", \
+      f"Expected curl1 uri to be 'docker://old-registry:5000/curl:latest', got: {curl1_uri}"
+
+    # Test 5: Verify module without compat works normally
+    new_curl1_path = "${moduleWithoutCompat.config.docker.images.curl1.path}"
+    assert new_curl1_path == "new-registry:5000/curl:latest", \
+      f"Expected new curl1 path to be 'new-registry:5000/curl:latest', got: {new_curl1_path}"
+
+    start_all()
+    client.succeed("echo 'Tests passed'")
+  '';
+}

--- a/tests/docker/multiple-registries.nix
+++ b/tests/docker/multiple-registries.nix
@@ -1,0 +1,91 @@
+{ images
+, evalModules
+, pkgs
+, ...
+}:
+let
+  inherit (module.config.docker) copyScript;
+  module = evalModules {
+    modules = [
+      ({ kubenix, ... }: {
+        imports = [ kubenix.modules.docker ];
+        docker = {
+          registry.host = "registry1:5000";
+
+          # Curl 1 image just uses defaults
+          images.curl1.image = images.curl;
+
+          # Curl 2 image uses runtime variables
+          images.curl2 = {
+            image = images.curl;
+            name = "ref+envsubst://$CURL2_PREFIX+curlref+envsubst://$CURL2_SUFFIX+";
+            registry.host = "registryref+envsubst://$CURL2_REG+:5000";
+            tag = "ref+envsubst://$CURL2_TAG";
+          };
+
+          # Nginx image is customized
+          images.nginx = {
+            image = images.nginx;
+            name = "custom-nginx";
+            registry.host = "registry2:5000";
+            tag = "nightly";
+          };
+        };
+      })
+    ];
+  };
+
+  registryModule = {
+    services.dockerRegistry = {
+      enable = true;
+      listenAddress = "0.0.0.0";
+      openFirewall = true;
+    };
+  };
+in
+pkgs.testers.runNixOSTest {
+  name = "docker-multiple-registries";
+  nodes = {
+    registry1 = registryModule;
+    registry2 = registryModule;
+
+    client = {
+      environment.systemPackages = [
+        copyScript
+        pkgs.skopeo
+      ];
+      environment.variables = {
+        CURL2_PREFIX = "kubenix-";
+        CURL2_SUFFIX = "2";
+        CURL2_REG = "2";
+        CURL2_TAG = "now";
+      };
+    };
+  };
+
+  testScript = ''
+    start_all()
+
+    registry1.wait_for_unit("docker-registry.service")
+    registry2.wait_for_unit("docker-registry.service")
+
+    # All images missing
+    client.fail("skopeo inspect --tls-verify=false docker://registry1:5000/curl:latest")
+    client.fail("skopeo inspect --tls-verify=false docker://registry2:5000/curl:latest")
+    client.fail("skopeo inspect --tls-verify=false docker://registry1:5000/kubenix-curl2:now")
+    client.fail("skopeo inspect --tls-verify=false docker://registry2:5000/kubenix-curl2:now")
+    client.fail("skopeo inspect --tls-verify=false docker://registry1:5000/custom-nginx:nightly")
+    client.fail("skopeo inspect --tls-verify=false docker://registry2:5000/custom-nginx:nightly")
+
+    # Push them
+    client.succeed("kubenix-push-images --insecure-policy --dest-tls-verify=false")
+
+    # All images present where they should
+    client.succeed("skopeo inspect --tls-verify=false docker://registry1:5000/curl:latest")
+    client.fail("skopeo inspect --tls-verify=false docker://registry2:5000/curl:latest")
+    client.fail("skopeo inspect --tls-verify=false docker://registry1:5000/kubenix-curl2:now")
+    client.succeed("skopeo inspect --tls-verify=false docker://registry2:5000/kubenix-curl2:now")
+    client.fail("skopeo inspect --tls-verify=false docker://registry1:5000/custom-nginx:nightly")
+    client.succeed("skopeo inspect --tls-verify=false docker://registry2:5000/custom-nginx:nightly")
+  '';
+}


### PR DESCRIPTION
refactor(docker): respect image settings, use vals, customizable registry protocol

This is a bunch of fixes together to cover a single use case, the one expressed in the included test: multiple images pushed to different destinations with a single script.

Image registry, name and tag can use `vals`, just like the rest of Kubenix, to expand dynamic or secret references on run time.

BREAKING CHANGE: `docker.copyScript` now puts a binary inside `$out/bin/kubenix-push-images`. The benefit is that now you can just `nix run .#kubenix.config.docker.copyScript`, which is more ergonomic.

BREAKING CHANGE: Registry definitions, which were never a URL, are no longer set in a `url` option. Instead of using `docker.registry.url` and `docker.images.*.registry` options are now consolidated into `[docker.registry|docker.images.*.registry].registry.{protocol,host}`, which behave as you'd expect.

BREAKING CHANGE: `docker.copyScript` push images to `docker.images.*.uri` instead of a handmade combination of the `imageName` and `imageTag` passthru attributes of the `docker.images.*.image` derivation.

@moduon MT-1075
