### PR TITLE
feat(ci): cache store, build packages via checks, split out release job

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,59 @@
+name: changelog
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+    paths:
+      - CHANGELOG.md
+
+env:
+  BYPASS_MESSAGE: A changelog entry is not necessary.
+
+jobs:
+  entry:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1, 2025-12-02
+        with:
+          fetch-depth: 0
+
+      - name: Check for a CHANGELOG.md entry
+        run: |
+          base="${{ github.event.pull_request.base.ref }}"
+
+          if git diff --name-only "origin/$base...HEAD" | grep -qx "CHANGELOG.md"; then
+            echo "✅ CHANGELOG.md was modified"
+            exit 0
+          fi
+
+          if git log "origin/$base..HEAD" --grep="$BYPASS_MESSAGE" --oneline | grep -q .; then
+            echo "✅ $BYPASS_MESSAGE"
+            exit 0
+          fi
+
+          echo "❌ No CHANGELOG.md entry."
+          echo
+          echo "Please either:"
+          echo "  1. Add an entry to CHANGELOG.md, or"
+          echo "  2. Include '$BYPASS_MESSAGE' in a commit message."
+          exit 1
+
+  validate:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1, 2025-12-02
+
+      - name: Validate CHANGELOG.md is parseable
+        uses: coditory/changelog-parser@4f567c6914ee75eff434b4d946393dfd254f8f98 # v1.0.2, 2020-11-08
+        with:
+          path: CHANGELOG.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,37 +1,57 @@
 name: tests
 
 on:
-  pull_request:
   push:
+    branches:
+      - main
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+  pull_request:
     branches:
       - main
 
 jobs:
   tests:
     runs-on: ubuntu-latest
+
     steps:
-      - name: checkout repo
-        uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1, 2025-12-02
 
-      - name: install nix
-        uses: cachix/install-nix-action@v31
+      - uses: nixbuild/nix-quick-install-action@2c9db80fb984ceb1bcaa77cdda3fdf8cfba92035 # v34, 2025-09-24
+        with:
+          nix_conf: |
+            keep-env-derivations = true
+            keep-outputs = true
 
-      - name: check flake
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7, 2026-01-08
+        with:
+          primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nix-${{ runner.os }}-
+          gc-max-store-size-linux: 2G
+          purge: true
+          purge-prefixes: nix-${{ runner.os }}-
+          purge-created: 0
+          purge-last-accessed: P1DT12H
+          purge-primary-key: never
+
+      - name: Build dev shell
+        run: nix develop -c true
+
+      # Builds every package too, via the `packages` check (see flake/checks.nix).
+      - name: Flake check
         run: nix -Lv flake check
 
-      - name: get latest tag
-        id: latest
-        uses: actions-ecosystem/action-get-latest-tag@v1
+  release:
+    needs: tests
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
-      - name: parse changelog
-        id: changelog
-        uses: coditory/changelog-parser@v1
-
-      - name: create release
-        id: release
-        uses: softprops/action-gh-release@v2
-        if: github.ref == 'refs/heads/main' && steps.changelog.outputs.version != steps.latest.outputs.tag
+    steps:
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2.5.0, 2025-12-01
         with:
-          files: ${{ steps.package.outputs.path }}
-          body: ${{ steps.changelog.outputs.description }}
-          tag_name: ${{ steps.changelog.outputs.version }}
+          generate_release_notes: true

--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -14,6 +14,12 @@
     in
     {
       checks = {
+        # Check that all packages build
+        # TODO: impure examples (helm/image/pod) aren't packages yet; once their default.nix
+        #   is pure they join `self'.packages` and build here automatically (matches packages.nix).
+        packages = pkgs.linkFarm "kubenix-packages"
+          (pkgs.lib.mapAttrsToList (name: path: { inherit name path; }) self'.packages);
+
         # TODO: access "success" derivation with nice testing utils for nice output
         testing = wasSuccess examples.testing.config.testing;
         label-filtering = pkgs.callPackage ../tests/label-filtering.nix {

--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -1,31 +1,44 @@
 { self, ... }:
 {
-  perSystem = { pkgs, self', evalModules, ... }: {
-    packages = {
-      default = pkgs.callPackage ../pkgs/kubenix.nix {
-        inherit evalModules;
-      };
-      docs = import ../docs {
-        inherit pkgs;
-        options = (evalModules {
-          modules = builtins.attrValues self.nixosModules.kubenix;
-        }).options;
-      };
-    } // pkgs.lib.attrsets.mapAttrs' (name: value: pkgs.lib.attrsets.nameValuePair "generate-${name}" value)
-      (builtins.removeAttrs (pkgs.callPackage ../pkgs/generators { }) [ "override" "overrideDerivation" ])
-    // (
-      # TODO: fix default.nix in all examples so they don't rely on inpure builtins.currentSystem
-      #   and then we can add all of them here.
-      pkgs.lib.attrsets.genAttrs' [
-        "namespaces"
-        "deployment"
-        "custom-resources"
-      ]
-        (name: pkgs.lib.nameValuePair
-          ("example-" + name)
-          (self'.packages.default.override {
-            module = ../docs/content/examples + "/${name}/module.nix";
-          }))
-    );
-  };
+  perSystem = { pkgs, self', evalModules, ... }:
+    let
+      inherit (pkgs.lib.attrsets) mapAttrs' filterAttrs nameValuePair;
+    in
+    {
+      packages = {
+        default = pkgs.callPackage ../pkgs/kubenix.nix {
+          inherit evalModules;
+        };
+        docs = import ../docs {
+          inherit pkgs;
+          options = (evalModules {
+            modules = builtins.attrValues self.nixosModules.kubenix;
+          }).options;
+        };
+      } // mapAttrs' (name: value: nameValuePair "generate-${name}" value)
+        (builtins.removeAttrs (pkgs.callPackage ../pkgs/generators { }) [ "override" "overrideDerivation" ])
+      // (
+        let
+          examplesDir = ../docs/content/examples;
+
+          # An example is packageable iff it exposes a pure `module.nix`; the rest only
+          # ship a default.nix pinned to the impure builtins.currentSystem, so they can't
+          # build.
+          # TODO: once those default.nix files are made pure they grow a module.nix and get
+          #   picked up here automatically; drop this note then (matches the one in checks.nix).
+          isPackageable = name: type:
+            type == "directory"
+              && builtins.pathExists (examplesDir + "/${name}/module.nix");
+
+          toPackage = name: _:
+            nameValuePair
+              ("example-" + name)
+              (self'.packages.default.override {
+                module = examplesDir + "/${name}/module.nix";
+              });
+        in
+        mapAttrs' toPackage
+          (filterAttrs isPackageable (builtins.readDir examplesDir))
+      );
+    };
 }


### PR DESCRIPTION
Stacked on:
- #136 

Please address that first.

## What this does
- on: scope `pull_request` to `main`; add semver tags so release-tagged commits re-run checks.
- tests: pin actions by SHA, add cache-nix-action (Nix store survives runs), build the dev shell.
- checks: new `packages` check link-farms every package, so `nix flake check` builds the whole
  set. Previously packages were only evaluated, not built.
- packages: example packages are derived from the filesystem (any example with a `module.nix`)
  instead of a hardcoded list.
- release: own job triggered on version tags; pinned softprops/action-gh-release with generated
  notes, replacing the changelog-parsing steps.

## Test plan
- `nix flake check` (builds all checks incl. the new `packages` check).
- CI: verify the `release` job only runs on `X.Y.Z` tag pushes.