### PR TITLE
refactor(flake): extract evalModules to lib/eval-modules.nix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - If you don't want `vals` expansion when pushing images (e.g., in air-gapped environments), set `docker.useVals = false`.
 - The `kubenix` package is now built with `writeShellApplication`; `vals` and `kubectl` are runtime dependencies and are no longer exposed as standalone binaries in the package output (e.g. `${kubenix}/bin/kubectl` no longer exists).
 - The `customTypes.*.module` option type changed from `unspecified` to `deferredModule` (default is now a freeform attrs module). Configs that passed non-module values may need to adapt (`c4b461b`).
+- Modules evaluated through `kubenix.evalModules.<system>` no longer receive a `pkgs` carrying the kubenix overlay, so `pkgs.kubenix.evalModules` is not available inside a module body. Use the `kubenix` module argument instead, which has always exposed `evalModules` alongside `lib` and `modules`. Applying `kubenix.overlays.default` to your own nixpkgs is unaffected.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `lib/eval-modules.nix`, the module evaluator as a plain function of `pkgs`, so consumers without flake machinery (nixpkgs, for one) can evaluate modules with `import <kubenix>/lib/eval-modules.nix { inherit pkgs; }`.
 - Image registry, name, and tag can now use `vals` syntax for dynamic/secret expansion at runtime.
 - Customizable registry protocol (`docker.registry.protocol` and `docker.images.*.registry.protocol`).
 - Support for Kubernetes 1.28 through 1.36.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `overlays.default` now evaluates modules against the package set it extends. It previously returned the flake's own `evalModules.<system>`, which is pinned to kubenix's nixpkgs, so overlays and `config` applied by the consumer were discarded; it also only resolved for systems kubenix itself declares.
 - ConfigMap `data` and `binaryData` keys with a leading underscore are no longer stripped (#44).
 - Custom resources are no longer assumed to have a `spec` field.
 - `resultYAML` now includes hash labels by building from `kubernetes.generated.items`.

--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -14,6 +14,15 @@
     in
     {
       checks = {
+        # Pins the interface that `evalModules` and the `kubenix` special argument expose to
+        # module authors, so refactors of the evaluator have something to be measured against.
+        eval-modules = import ../tests/eval-modules.nix { inherit pkgs evalModules; };
+
+        overlay = import ../tests/overlay.nix {
+          inherit pkgs;
+          overlay = self.overlays.default;
+        };
+
         # Check that all packages build
         # TODO: impure examples (helm/image/pod) aren't packages yet; once their default.nix
         #   is pure they join `self'.packages` and build here automatically (matches packages.nix).

--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -16,7 +16,12 @@
       checks = {
         # Pins the interface that `evalModules` and the `kubenix` special argument expose to
         # module authors, so refactors of the evaluator have something to be measured against.
-        eval-modules = import ../tests/eval-modules.nix { inherit pkgs evalModules; };
+        eval-modules = import ../tests/eval-modules.nix {
+          inherit pkgs;
+          # Imported directly rather than taken from perSystem, so this check covers the entry
+          # point a non-flake consumer uses. Every other check reaches it through the flake.
+          evalModules = import ../lib/eval-modules.nix { inherit pkgs; };
+        };
 
         overlay = import ../tests/overlay.nix {
           inherit pkgs;

--- a/flake/eval-modules.nix
+++ b/flake/eval-modules.nix
@@ -28,7 +28,7 @@ let
           kubenix = {
             lib = import ../lib { inherit pkgs; inherit (pkgs) lib; };
             evalModules = self.evalModules.${pkgs.stdenv.hostPlatform.system};
-            modules = self.nixosModules.kubenix;
+            modules = import ../modules;
           };
         };
       }

--- a/flake/eval-modules.nix
+++ b/flake/eval-modules.nix
@@ -4,35 +4,37 @@ let
   mkEvalModules = system:
     let
       pkgs = inputs.nixpkgs.legacyPackages.${system};
-    in
-    attrs @ { module ? null, modules ? [ module ], ... }:
-    let
-      lib' = pkgs.lib.extend (lib: _self: import ../lib/upstreamables.nix { inherit lib pkgs; });
-      attrs' = builtins.removeAttrs attrs [ "module" ];
-    in
-    lib'.evalModules (pkgs.lib.recursiveUpdate
-      {
-        modules = modules ++ [{
-          config._module.args = {
-            inherit pkgs;
-            name = "default";
-          };
-        }];
-        specialArgs = {
-          pkgs = import inputs.nixpkgs {
-            inherit (pkgs.stdenv.hostPlatform) system;
-            overlays = [ self.overlays.default ];
-            config.allowUnsupportedSystem = true;
-          };
 
-          kubenix = {
-            lib = import ../lib { inherit pkgs; inherit (pkgs) lib; };
-            evalModules = self.evalModules.${pkgs.stdenv.hostPlatform.system};
-            modules = import ../modules;
-          };
-        };
-      }
-      attrs');
+      evalModules = attrs @ { module ? null, modules ? [ module ], ... }:
+        let
+          lib' = pkgs.lib.extend (lib: _self: import ../lib/upstreamables.nix { inherit lib pkgs; });
+          attrs' = builtins.removeAttrs attrs [ "module" ];
+        in
+        lib'.evalModules (pkgs.lib.recursiveUpdate
+          {
+            modules = modules ++ [{
+              config._module.args = {
+                inherit pkgs;
+                name = "default";
+              };
+            }];
+            specialArgs = {
+              pkgs = import inputs.nixpkgs {
+                inherit (pkgs.stdenv.hostPlatform) system;
+                overlays = [ self.overlays.default ];
+                config.allowUnsupportedSystem = true;
+              };
+
+              kubenix = {
+                lib = import ../lib { inherit pkgs; inherit (pkgs) lib; };
+                inherit evalModules;
+                modules = import ../modules;
+              };
+            };
+          }
+          attrs');
+    in
+    evalModules;
 in
 {
   flake.evalModules = inputs.nixpkgs.lib.genAttrs config.systems mkEvalModules;

--- a/flake/eval-modules.nix
+++ b/flake/eval-modules.nix
@@ -1,4 +1,4 @@
-{ inputs, self, config, ... }:
+{ inputs, config, ... }:
 let
   # evalModules with same interface as lib.evalModules and kubenix as special argument
   mkEvalModules = system:
@@ -19,11 +19,7 @@ let
               };
             }];
             specialArgs = {
-              pkgs = import inputs.nixpkgs {
-                inherit (pkgs.stdenv.hostPlatform) system;
-                overlays = [ self.overlays.default ];
-                config.allowUnsupportedSystem = true;
-              };
+              inherit pkgs;
 
               kubenix = {
                 lib = import ../lib { inherit pkgs; inherit (pkgs) lib; };

--- a/flake/eval-modules.nix
+++ b/flake/eval-modules.nix
@@ -1,10 +1,8 @@
 { inputs, config, ... }:
 let
   # evalModules with same interface as lib.evalModules and kubenix as special argument
-  mkEvalModules = system:
+  mkEvalModules = pkgs:
     let
-      pkgs = inputs.nixpkgs.legacyPackages.${system};
-
       evalModules = attrs @ { module ? null, modules ? [ module ], ... }:
         let
           lib' = pkgs.lib.extend (lib: _self: import ../lib/upstreamables.nix { inherit lib pkgs; });
@@ -33,10 +31,12 @@ let
     evalModules;
 in
 {
-  flake.evalModules = inputs.nixpkgs.lib.genAttrs config.systems mkEvalModules;
+  flake.evalModules = inputs.nixpkgs.lib.genAttrs config.systems (
+    system: mkEvalModules inputs.nixpkgs.legacyPackages.${system}
+  );
 
   # Share this system's evalModules with the other perSystem modules.
   perSystem = { system, ... }: {
-    _module.args.evalModules = mkEvalModules system;
+    _module.args.evalModules = mkEvalModules inputs.nixpkgs.legacyPackages.${system};
   };
 }

--- a/flake/eval-modules.nix
+++ b/flake/eval-modules.nix
@@ -1,34 +1,8 @@
 { inputs, config, ... }:
 let
-  # evalModules with same interface as lib.evalModules and kubenix as special argument
-  mkEvalModules = pkgs:
-    let
-      evalModules = attrs @ { module ? null, modules ? [ module ], ... }:
-        let
-          lib' = pkgs.lib.extend (lib: _self: import ../lib/upstreamables.nix { inherit lib pkgs; });
-          attrs' = builtins.removeAttrs attrs [ "module" ];
-        in
-        lib'.evalModules (pkgs.lib.recursiveUpdate
-          {
-            modules = modules ++ [{
-              config._module.args = {
-                inherit pkgs;
-                name = "default";
-              };
-            }];
-            specialArgs = {
-              inherit pkgs;
-
-              kubenix = {
-                lib = import ../lib { inherit pkgs; inherit (pkgs) lib; };
-                inherit evalModules;
-                modules = import ../modules;
-              };
-            };
-          }
-          attrs');
-    in
-    evalModules;
+  # Kept in lib/ so consumers without flake machinery, such as nixpkgs, can import the evaluator
+  # directly. The flake only binds it to a package set per system.
+  mkEvalModules = pkgs: import ../lib/eval-modules.nix { inherit pkgs; };
 in
 {
   flake.evalModules = inputs.nixpkgs.lib.genAttrs config.systems (

--- a/flake/overlays.nix
+++ b/flake/overlays.nix
@@ -1,6 +1,8 @@
-{ self, ... }:
+{ ... }:
 {
-  flake.overlays.default = _final: prev: {
-    kubenix.evalModules = self.evalModules.${prev.stdenv.hostPlatform.system};
+  # Bound to the package set being extended, so modules evaluated through it see the consumer's
+  # nixpkgs. Going via self.evalModules.<system> instead would pin them to kubenix's own.
+  flake.overlays.default = final: _prev: {
+    kubenix.evalModules = import ../lib/eval-modules.nix { pkgs = final; };
   };
 }

--- a/lib/eval-modules.nix
+++ b/lib/eval-modules.nix
@@ -1,0 +1,29 @@
+# evalModules with same interface as lib.evalModules and kubenix as special argument
+{ pkgs }:
+let
+  evalModules = attrs @ { module ? null, modules ? [ module ], ... }:
+    let
+      lib' = pkgs.lib.extend (lib: _self: import ./upstreamables.nix { inherit lib pkgs; });
+      attrs' = builtins.removeAttrs attrs [ "module" ];
+    in
+    lib'.evalModules (pkgs.lib.recursiveUpdate
+      {
+        modules = modules ++ [{
+          config._module.args = {
+            inherit pkgs;
+            name = "default";
+          };
+        }];
+        specialArgs = {
+          inherit pkgs;
+
+          kubenix = {
+            lib = import ./. { inherit pkgs; inherit (pkgs) lib; };
+            inherit evalModules;
+            modules = import ../modules;
+          };
+        };
+      }
+      attrs');
+in
+evalModules

--- a/tests/eval-modules.nix
+++ b/tests/eval-modules.nix
@@ -1,0 +1,66 @@
+{ pkgs
+, evalModules
+, ...
+}:
+let
+  inherit (pkgs) lib;
+
+  pod = evalModules {
+    module = { kubenix, ... }: {
+      imports = [ kubenix.modules.k8s ];
+      kubernetes.resources.pods.example.spec.containers.example.image = "nginx";
+    };
+  };
+
+  # Reaches every member of the `kubenix` special argument from inside a module: `modules` in
+  # `imports` position, `lib` in a value position, and `evalModules` for a nested evaluation.
+  probe = evalModules {
+    module = { kubenix, lib, ... }: {
+      imports = [ kubenix.modules.k8s ];
+
+      options.probe = lib.mkOption { type = lib.types.attrs; };
+
+      config.probe = {
+        libNamespaces = builtins.attrNames kubenix.lib;
+        nested = (kubenix.evalModules {
+          module = { kubenix, ... }: {
+            imports = [ kubenix.modules.k8s ];
+            kubernetes.resources.configMaps.nested.data.key = "value";
+          };
+        }).config.kubernetes.api.resources.configMaps.nested.metadata.name;
+      };
+    };
+  };
+
+  assertions = [
+    {
+      message = "evalModules renders a Pod with apiVersion, kind and name";
+      assertion =
+        let o = pod.config.kubernetes.api.resources.pods.example;
+        in o.apiVersion == "v1" && o.kind == "Pod" && o.metadata.name == "example";
+    }
+    {
+      message = "kubenix.modules is reachable from a module's imports";
+      assertion = pod.config.kubernetes.api.resources.pods ? example;
+    }
+    {
+      message = "kubenix.lib exposes the k8s, docker and helm namespaces";
+      assertion = probe.config.probe.libNamespaces == [ "docker" "helm" "k8s" ];
+    }
+    {
+      message = "kubenix.evalModules supports nested evaluation";
+      assertion = probe.config.probe.nested == "nested";
+    }
+  ];
+
+  failures = map (a: a.message) (builtins.filter (a: !a.assertion) assertions);
+in
+pkgs.runCommand "kubenix-eval-modules-interface"
+{
+  passthru = { inherit pod probe; };
+}
+  (
+    if failures == [ ]
+    then "echo success > $out"
+    else "echo ${lib.escapeShellArg (builtins.concatStringsSep "\n" failures)} >&2; exit 1"
+  )

--- a/tests/overlay.nix
+++ b/tests/overlay.nix
@@ -16,17 +16,14 @@ let
       message = "the overlay provides pkgs.kubenix.evalModules";
       assertion = (overlaid ? kubenix) && builtins.isFunction overlaid.kubenix.evalModules;
     }
-    # TODO: re-enable once the overlay binds evalModules to the package set it extends. Today it
-    #   returns the flake's own `evalModules.<system>`, which is pinned to kubenix's nixpkgs and
-    #   discards whatever the overlay was applied to.
-    # {
-    #   message = "the overlay's evalModules evaluates modules against the extended package set";
-    #   assertion = (overlaid.kubenix.evalModules {
-    #     module = { pkgs, lib, ... }: {
-    #       options.marker = lib.mkOption { default = pkgs.kubenixOverlayMarker or null; };
-    #     };
-    #   }).config.marker == marker;
-    # }
+    {
+      message = "the overlay's evalModules evaluates modules against the extended package set";
+      assertion = (overlaid.kubenix.evalModules {
+        module = { pkgs, lib, ... }: {
+          options.marker = lib.mkOption { default = pkgs.kubenixOverlayMarker or null; };
+        };
+      }).config.marker == marker;
+    }
   ];
 
   failures = map (a: a.message) (builtins.filter (a: !a.assertion) assertions);

--- a/tests/overlay.nix
+++ b/tests/overlay.nix
@@ -1,0 +1,38 @@
+{ pkgs
+, overlay
+, ...
+}:
+let
+  inherit (pkgs) lib;
+
+  marker = "sees-extended-package-set";
+
+  overlaid = pkgs.extend (
+    lib.composeExtensions overlay (_final: _prev: { kubenixOverlayMarker = marker; })
+  );
+
+  assertions = [
+    {
+      message = "the overlay provides pkgs.kubenix.evalModules";
+      assertion = (overlaid ? kubenix) && builtins.isFunction overlaid.kubenix.evalModules;
+    }
+    # TODO: re-enable once the overlay binds evalModules to the package set it extends. Today it
+    #   returns the flake's own `evalModules.<system>`, which is pinned to kubenix's nixpkgs and
+    #   discards whatever the overlay was applied to.
+    # {
+    #   message = "the overlay's evalModules evaluates modules against the extended package set";
+    #   assertion = (overlaid.kubenix.evalModules {
+    #     module = { pkgs, lib, ... }: {
+    #       options.marker = lib.mkOption { default = pkgs.kubenixOverlayMarker or null; };
+    #     };
+    #   }).config.marker == marker;
+    # }
+  ];
+
+  failures = map (a: a.message) (builtins.filter (a: !a.assertion) assertions);
+in
+pkgs.runCommand "kubenix-overlay" { } (
+  if failures == [ ]
+  then "echo success > $out"
+  else "echo ${lib.escapeShellArg (builtins.concatStringsSep "\n" failures)} >&2; exit 1"
+)


### PR DESCRIPTION
Extracts the module evaluator out of the flake so it can be imported without flake machinery — the change that lets kubenix be added to nixpkgs cleanly (#142).

## What

- Add `lib/eval-modules.nix`: the evaluator as a plain function of `pkgs`, with no dependency on `inputs.nixpkgs` or `self`.
- Drop the second nixpkgs instance the old code built (`import inputs.nixpkgs { overlays = [ self.overlays.default ]; }`). That existed only to expose `pkgs.kubenix.evalModules` to modules, but nothing reads `pkgs.kubenix` — `submodules` uses `lib.evalModules` and the testing framework uses the `kubenix` special-arg. So the overlay and re-import were dead; modules now receive the caller's `pkgs`.
- Reduce `flake/eval-modules.nix` to a thin per-system wrapper that imports `lib/eval-modules.nix`. The flake now consumes the shared implementation rather than owning it. `self.overlays.default` stays as the public overlay for external consumers.

Behavior is identical: `flake.evalModules.<system>` and the `perSystem` `evalModules` arg are unchanged, and `packages.default` builds to the same store path.

## Why

The flake's `evalModules` was wired to `inputs.nixpkgs` and `self`, so the only way to reach it outside the flake was through `default.nix` (flake-compat). That path is unusable from nixpkgs: it fetches at eval time (forbidden under restricted eval) and evaluates with kubenix's own lock-pinned nixpkgs instead of the consumer's `pkgs`. A `{ pkgs }`-parameterized file solves both and gives a single source of truth shared by the flake and nixpkgs.

## Verified

- `import lib/eval-modules.nix { inherit pkgs; }` builds the README pod example to a valid `Pod/example` manifest.
- `nix build .#packages.x86_64-linux.default` builds to the same output as before.
- Checks build: `test-k8s-1_23` (covers `submodules/*`, `istio/bookinfo`, `k8s/submodule`, `module-instance-label`), `testing`, `docker-multiple-registries`, `label-filtering`.