### PR TITLE
docs: tips-n-tricks/deploy.md: ensure directory is created

### DIFF
--- a/docs/content/tips-n-tricks/deploy.md
+++ b/docs/content/tips-n-tricks/deploy.md
@@ -37,6 +37,7 @@ As such, on a server node, we can write kubenix's output there.
   # now we can link our file into the appropriate directory
   # and k3s will handle the rest
   system.activationScripts.kubenix.text = ''
+    mkdir -p /var/lib/rancher/k3s/server/manifests
     ln -sf /etc/kubenix.yaml /var/lib/rancher/k3s/server/manifests/kubenix.yaml
   '';
 }


### PR DESCRIPTION
On first boot, the directory might not be created, causing the symlink to fail.

This is the case for example in NixOS VMs ([example config](https://codeberg.org/27/ft_lgtm/src/commit/35c2f0fa7a7a0823ff0de43676d9c51c5442ddf8/vm.nix))