### PR TITLE
feat(dev): use numtide devshell instead of pkgs.mkShell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,25 @@
 {
   "nodes": {
+    "devshell": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768818222,
+        "narHash": "sha256-460jc0+CZfyaO8+w8JNtlClB2n4ui1RbHfPTLkpwhU8=",
+        "owner": "numtide",
+        "repo": "devshell",
+        "rev": "255a2b1725a20d060f566e4755dbf571bbbb5f76",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "devshell",
+        "type": "github"
+      }
+    },
     "flake-compat": {
       "flake": false,
       "locked": {
@@ -82,6 +102,7 @@
     },
     "root": {
       "inputs": {
+        "devshell": "devshell",
         "flake-compat": "flake-compat",
         "flake-parts": "flake-parts",
         "import-tree": "import-tree",

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,11 @@
       flake = false;
     };
 
+    devshell = {
+      url = "github:numtide/devshell";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+
     treefmt-nix = {
       url = "github:numtide/treefmt-nix";
       inputs.nixpkgs.follows = "nixpkgs";

--- a/flake/devshell.nix
+++ b/flake/devshell.nix
@@ -1,8 +1,12 @@
-{ ... }:
+{ inputs, ... }:
 {
+  imports = [ inputs.devshell.flakeModule ];
+
   perSystem = { pkgs, ... }: {
-    devShells.default = pkgs.mkShell {
-      buildInputs = with pkgs; [
+    devshells.default = {
+      devshell.name = "kubenix";
+
+      packages = with pkgs; [
         dive
         k9s
         k3d


### PR DESCRIPTION
flake/devshell.nix:
- Names the shell kubenix so its banner and menu identify the project rather than "devshell".
- Same tool set as before; the payoff is the room it leaves for `commands` and `env` entries, which mkShell only expresses as shellHook string-mangling.

A changelog entry is not necessary.